### PR TITLE
Rules/resolution

### DIFF
--- a/signature/alethe.eo
+++ b/signature/alethe.eo
@@ -48,7 +48,7 @@
 ; args:
 ; - formula Bool: An arbitrary formula.
 ; return: >
-;   A formula equivalent to "formula", with leading double negations cancelled.
+;   A formula equivalent to `formula`, with leading double negations cancelled.
 (program $remove_double_negation ((formula Bool))
          :signature (Bool) Bool
          (
@@ -58,7 +58,7 @@
            formula
            )
 
-          (; { "formula" does not begin with a double negation }
+          (; { `formula` does not begin with a double negation }
            ($remove_double_negation formula)
 
            formula
@@ -70,7 +70,7 @@
 ; args:
 ; - clause Bool: A clause built with @cl.
 ; return: >
-;    A clause logically equivalent to "clause", where leading double negations
+;    A clause logically equivalent to `clause`, where leading double negations
 ;    in disjuncts are removed.
 (program $normalize_single_clause ((formula Bool) (formulas Bool :list))
          :signature (Bool) Bool
@@ -100,8 +100,8 @@
 ; args:
 ; - clauses Bool: And-list of clauses.
 ; return: >
-;    An and-list of clauses logically equivalent to "clauses", where each single
-;    "clause" is normalized, according to $normalize_single_clause.
+;    An and-list of clauses where each single clause is normalized according 
+;    to $normalize_single_clause.
 (program $normalize_clauses ((clause Bool) (clauses Bool :list))
          :signature (Bool) Bool
          (
@@ -122,14 +122,15 @@
 
 ; program: $remove_pivot_from_clause
 ; args:
-; - pivot Bool: Pivot literal contained in "clause".
+; - pivot Bool: Pivot literal contained in `clause`.
 ; - clause Bool: Clause containing the pivot.
-; return: The clause obtained from removing "pivot" from "clause".
-; note: PRE : { "pivot" is contained in "clause" 
-;                && 
-;               "pivot" is normalized
-;                && 
-;               "clause" is normalized }
+; return: The clause obtained from removing `pivot` from `clause`.
+; note: >
+;  PRE : { `pivot` is contained in `clause` 
+;          &&
+;          `pivot` is normalized
+;          &&
+;          `clause` is normalized }
 (program $remove_pivot_from_clause ((hd Bool) (tail Bool :list) 
                                       (pivot Bool))
          :signature (Bool Bool) Bool
@@ -163,12 +164,13 @@
 ; - pivot Bool: >
 ;   Pivot to be found and removed from the corresponding clause, if it exists.
 ; - clauses Bool: And-list of clauses.
-; return: The clause containing "pivot", without "pivot" itself.
-; note: PRE : { "pivot" is contained in some clause from "clauses"
+; return: The clause containing `pivot`, without `pivot` itself.
+; note: >
+;  PRE : { `pivot` is contained in some clause from `clauses`
 ;                && 
-;               "pivot" is normalized
+;               `pivot` is normalized
 ;                && 
-;               "clause" is normalized }
+;               `clause` is normalized }
 (program $find_and_remove_pivot_from_clauses ((clause Bool) (clauses Bool :list) 
                                                (pivot Bool))
          :signature (Bool Bool) Bool
@@ -184,7 +186,7 @@
                     )
            )
 
-          (; By pre, "clause" should contain "pivot".
+          (; By pre, `clause` should contain `pivot`.
            ; { clause is just a single @cl clause }
            ($find_and_remove_pivot_from_clauses pivot clause)
 
@@ -199,13 +201,13 @@
 ; - pivot Bool: >
 ;   Pivot that is being considered in the current binary resolution step.
 ; - clauses Bool: And-list of clauses.
-; return: The And-list of clauses without the clause containing "pivot".
+; return: The And-list of clauses without the clause containing `pivot`.
 ; note: >
-;   PRE : { "pivot" is contained in some clause from "clauses"
+;   PRE : { `pivot` is contained in some clause from `clauses`
 ;           && 
-;           "pivot" is normalized
+;           `pivot` is normalized
 ;           && 
-;          "clause" is normalized }
+;          `clause` is normalized }
 ;   While this function repeats part of the work done by 
 ;   $find_and_remove_pivot_from_clauses, it is added to simplify the task
 ;   of identifying which are the remaining clauses upon which we must continue
@@ -225,7 +227,7 @@
                     )
            )
 
-          (; By pre, "clause" should contain "pivot".
+          (; By pre, `clause` should contain `pivot`.
            ; { clause is just a single @cl clause }
            ($return_untouched_clauses pivot clause)
 
@@ -240,10 +242,10 @@
 ; - pivots @VarList: A list of pivots used during resolution.
 ; - conclusion Bool: Conclusion provided to the rule.
 ; return: >
-;   A boolean indicating if "conclusion" is a resolvent that can be
-;   obtained from applying resolution over "clauses", using the pivots
-;   contained in "pivots", in the same order of their appearance in the list.
-; note: PRE : { "clauses" are normalized: double negation is simplified }
+;   A boolean indicating if `conclusion` is a resolvent that can be
+;   obtained from applying resolution over `clauses`, using the pivots
+;   contained in `pivots`, in the same order of their appearance in the list.
+; note: PRE : { `clauses` are normalized: double negation is simplified }
 (program $check_resolution_with_normalized_clauses  ((clauses Bool)
                                                      (polarity Bool)
                                                      (pivot Bool) (pivots @VarList :list)
@@ -251,7 +253,7 @@
   (Bool @VarList Bool) Bool
   (
    (; Carcara's elaboration indicates the pivots followed by their "polarity": in 
-    ; this case, true means that "pivot" appears exactly as it is, in some clause.
+    ; this case, true means that `pivot` appears exactly as it is, in some clause.
     ($check_resolution_with_normalized_clauses clauses (@varlist pivot polarity 
                                                                  pivots)
                                                conclusion)
@@ -331,9 +333,9 @@
 ; - pivots @VarList: A list of pivots used during resolution.
 ; - conclusion Bool: Conclusion provided to the rule.
 ; return: >
-;   A boolean indicating if "conclusion" is a resolvent that can be
-;   obtained from applying chain resolution over "clauses", using the pivots
-;   contained in "pivots", in the same order of their appearance in the list.
+;   A boolean indicating if `conclusion` is a resolvent that can be
+;   obtained from applying chain resolution over `clauses`, using the pivots
+;   contained in `pivots`, in the same order of their appearance in the list.
 (program $check_resolution ((clauses Bool) (pivots @VarList)
                             (conclusion Bool))
   (Bool @VarList Bool) Bool
@@ -348,14 +350,20 @@
 )
 
 ; rule: th_resolution
-; implements: TODO?
 ; premises:
-; - premises Bool:
-; - conclusion Bool:
-; - pivots @VarList:
+; - premises Bool: And-list of premises over which "resolution" is applied.
 ; args:
-; requires:
-; conclusion:
+; - pivots @VarList: >
+;   @VarList of pivots used in each binary resolution step, each pivot followed
+;   by its polarity.
+; requires: >
+;   For the conclusion of the rule to be result of the application of the chain
+;   resolution rule, over the given premises, using the provided pivots.
+; conclusion-explicit: >
+;   A clause containing a subset of the disjuncts the belong to the premises,
+;   obtained through chain resolution over the premises.
+; note: This rule is not emitted by the sat-solver. See rule `resolution`
+;   for the rule emitted by the sat-solver.
 (declare-rule th_resolution ((premises Bool) (conclusion Bool) (pivots @VarList))
   :premise-list premises and
   :args (pivots)
@@ -368,14 +376,19 @@
 ;-------------
 
 ; rule: resolution
-; implements: TODO?
 ; premises:
-; - premises Bool:
-; - conclusion Bool:
-; - pivots @VarList:
+; - premises Bool: And-list of premises over which "resolution" is applied.
 ; args:
-; requires:
-; conclusion:
+; - pivots @VarList: >
+;   @VarList of pivots used in each binary resolution step, each pivot followed
+;   by its polarity.
+; requires: >
+;   For the conclusion of the rule to be result of the application of the chain
+;   resolution rule, over the given premises, using the provided pivots.
+; conclusion-explicit: >
+;   A clause containing a subset of the disjuncts the belong to the premises,
+;   obtained through chain resolution over the premises.
+; note: This rule is emitted only by the sat-solver.
 (declare-rule resolution ((premises Bool) (conclusion Bool) (pivots @VarList))
   :premise-list premises and
   :args (pivots)
@@ -445,7 +458,7 @@
 ; - premise Bool: Last step before the application of "subproof".
 ; - conclusion Bool: Conclusion of the "subproof" step.
 ; return: >
-;   A boolean indicating if "conclusion" is of the form 
+;   A boolean indicating if `conclusion` is of the form 
 ;   (@cl (not assumption), premise)
 (program $check_subproof ((assumption Bool) (premise Bool) 
                           (conclusion Bool))
@@ -630,7 +643,7 @@
 ;    and bounded variables lhs_vars and rhs_vars.
 ; return: >
 ;    A boolean resulting from the conjunction of the following conditions:
-;    - Every variable in rhs_vars appear fixed in "new_context".
+;    - Every variable in rhs_vars appear fixed in `new_context`.
 ;    - Vars in lhs_vars are substituted by rhs_vars
 ;    - rhs_vars should not appear free in (Q lhs_vars lhs_body)
 ;    - rhs_vars should not appear in the first part of the new_context (old_context)
@@ -650,7 +663,7 @@
                          (forall rhs_vars rhs_body))))
 
     (eo::and
-     ; Every variable in rhs_vars appear fixed in "new_context".
+     ; Every variable in rhs_vars appear fixed in `new_context`.
      ($context_vars_are_fixed new_context rhs_vars)
 
      ; Vars in lhs_vars are substituted by rhs_vars.
@@ -689,7 +702,7 @@
 
     (eo::and
 
-     ; Every variable in rhs_vars appear fixed in "context".
+     ; Every variable in rhs_vars appear fixed in `context`.
      ($context_vars_are_fixed new_context rhs_vars)
 
      ; Vars in lhs_vars are substituted by rhs_vars
@@ -799,8 +812,8 @@
 ; - new_context Bool: Context of sko_ex premise.
 ; - ex_vars @VarList: List of existentially quantified variables.
 ; return: >
-;    Checks that "new_context" contains the expected mapping between each variable in
-;    "ex_vars" and its corresponding skolem term.
+;    Checks that `new_context` contains the expected mapping between each variable in
+;    `ex_vars` and its corresponding skolem term.
 (program $check_sko_ex_new_context ((ex_body Bool) (new_context Bool) (ex_vars @VarList))
          (Bool Bool @VarList) Bool
          (
@@ -839,7 +852,7 @@
      ($context_is_extended new_context old_context)
 
      ; new_context should contain the expected mapping between each variable in
-     ; "ex_vars" and its corresponding skolem term.
+     ; `ex_vars` and its corresponding skolem term.
      ($check_sko_ex_new_context lhs new_context ex_vars)
 
      ; ex_vars should not appear in the first part of the new_context (old_context)
@@ -1108,7 +1121,7 @@
 ; - premises Bool: Equivalence premises given to rule trans, chained through "and".
 ; - conclusion Bool: Conclusion given to rule trans. Must be built with @cl.
 ; return: >
-;   A boolean indicating if "conclusion" is the equivalence resulting from
+;   A boolean indicating if `conclusion` is the equivalence resulting from
 ;   the transitivity of equivalence, identifying the lhs of the first 
 ;   premise equivalence with the rhs of the last premise equivalence.
 (program $check_trans ((A Type) (lhs A) (lhs_1 A) (lhs_2 A)
@@ -1308,7 +1321,7 @@
 ;   Premises given to rule cong. Must be an and-list of each premise (equality).
 ; - conclusion Bool: Conclusion clause given to rule cong.
 ; return: >
-;   A boolean indicating if "conclusion" follows from the and-list of premises
+;   A boolean indicating if `conclusion` follows from the and-list of premises
 ;   given.
 (program $check_cong ((T Type) (U Type) (f_lhs (-> T U)) (lhs U) (f_rhs (-> T U)) (rhs U) 
                       (premises Bool))
@@ -1458,8 +1471,8 @@
 ; - conclusion Bool    : >
 ;   Conclusion provided to the rule. 
 ; return: >
-;   A boolean indicating if "conclusion" is a conjunct from 
-;   "premise", with index "index".
+;   A boolean indicating if `conclusion` is a conjunct from 
+;   `premise`, with index `index`.
 (program $check_and ((premise Bool) (premise_non_cl Bool) (index Int) (conclusion Bool))
   (Bool Int Bool) Bool
   (
@@ -1505,8 +1518,8 @@
 ; - conclusion Bool    : >
 ;   Conclusion provided to the rule. 
 ; return: >
-;   A boolean indicating if "conclusion" is a conjunct from "premise" (after
-;   applying DeMorgan's law), in position "index".
+;   A boolean indicating if `conclusion` is a conjunct from `premise` (after
+;   applying DeMorgan's law), in position `index`.
 (program $check_not_or ((disjuncts Bool) (premise_non_cl Bool) (index Int) (conclusion Bool))
   (Bool Int Bool) Bool
   (; To facilitate the use of the program, we allow 
@@ -1552,7 +1565,7 @@
 ; - conclusion Bool: >
 ;   Conclusion provided to the rule. 
 ; return: >
-;   A boolean indicating if "conclusion" is equivalent to "premise", but built 
+;   A boolean indicating if `conclusion` is equivalent to `premise`, but built 
 ;   with @cl.
 (program $check_or ((premise Bool) (conclusion Bool))
   (Bool Bool) Bool
@@ -1572,7 +1585,7 @@
 ;   The clause, built with the "or" operator, over which the rule is applied. 
 ;   It could be embedded within a single-term clause built with @cl.
 ; requires: >
-;   The conclusion should be a clause equivalent to "premise", 
+;   The conclusion should be a clause equivalent to `premise`, 
 ;   but built with @cl.
 ; conclusion-explicit: >
 ;   A conclusion satisfying the previous side-condition.
@@ -1592,9 +1605,9 @@
 ; - conclusion Bool: >
 ;   The conclusion provided to the not_and rule.
 ; return: >
-;   A boolean indicating if "conclusion" is a clause built with
+;   A boolean indicating if `conclusion` is a clause built with
 ;   @cl, where each disjunct is negated and corresponds to some conjunct from
-;   "premise".
+;   `premise`.
 (program $check_not_and ((conjunction Bool) (conclusion Bool))
   (Bool Bool) Bool
   (
@@ -1778,7 +1791,7 @@
 ;   The conclusion clause provided to the rule. It must be always built with
 ;   @cl.
 ; return: >
-;   A boolean indicating if "conclusion" satisfies the property of being
+;   A boolean indicating if `conclusion` satisfies the property of being
 ;   an instance of the weakening rule for implication, where the antecedent is 
 ;   a conjunction.
 (program $check_and_pos ((pos Int) (antecedent Bool) (consequent Bool))
@@ -1826,7 +1839,7 @@
 ;   This should be the conclusion to the application of and_neg. It must be
 ;   a clause built with @cl.
 ; return: >
-;   A boolean indicating if "conclusion" is an instance of excluded middle,
+;   A boolean indicating if `conclusion` is an instance of excluded middle,
 ;   for a proposition of the form phi_1 /\ ... /\ phi_n.
 (program $check_and_neg ((left_disjunct Bool) (right_disjunct Bool :list))
   (Bool) Bool
@@ -1896,7 +1909,7 @@
 ;   The conclusion clause provided to the rule. It must be always built with
 ;   @cl.
 ; return: >
-;   A boolean indicating if "conclusion" satisfies the property of being
+;   A boolean indicating if `conclusion` satisfies the property of being
 ;   an instance of the weakening rule for implication, with the form 
 ;   not phi_k, phi_0 \/ ... \/ phi_n, with 0 <= k <= n.
 (program $check_or_neg ((index Int) (left_disjunct Bool) (right_disjunct Bool))
@@ -2671,7 +2684,7 @@
 ;   type A.
 ; - conjunctions Bool: A conjunctions of inequalities of the form (not (= lhs' rhs'))
 ; return: >
-;   A boolean indicating if ineq appears in "conjunctions", modulo symmetry of the
+;   A boolean indicating if ineq appears in `conjunctions`, modulo symmetry of the
 ;   equality within ineq.
 (program $conjunction_contains_ineq ((A Type) (lhs A) (rhs A) (hd Bool) (tl Bool :list))
   (Bool Bool) Bool
@@ -2776,7 +2789,7 @@
 ; args:
 ; - conclusion Bool: The conclusion give to the distinct_elim rule.
 ; return:
-; A Boolean indicating if the given "conclusion" has the shape
+; A Boolean indicating if the given `conclusion` has the shape
 ; (distinct 𝑡1 … 𝑡𝑛) ≈ ⋀ 𝑡𝑖 ≈/≈ 𝑡𝑗.
 (program $check_distinct_elim ((A Type) (hd A) (inequalities Bool) (conjunctions Bool))
   (Bool) Bool

--- a/signature/alethe.eo
+++ b/signature/alethe.eo
@@ -10,7 +10,7 @@
 ;   This models the following (taken from the standard spec.):
 ;   "A proof checker must not accept as valid a proof that contains this
 ;     rule even if the checker can somehow check this rule."
-(declare-rule hole ((conclusion Bool))
+(declare-rule hole ((conclusion Bool :list))
   :conclusion-explicit (@cl conclusion)
   :sorry
 )
@@ -44,33 +44,138 @@
 ; Rule 6: th_resolution
 ;-------------
 
+(program $normalize_formula ((formula Bool))
+         :signature (Bool) Bool
+         (
+          (
+           ($normalize_formula (not (not formula)))
+
+           formula
+           )
+
+          (; { "formula" does not begin with a double negation }
+           ($normalize_formula formula)
+
+           formula
+           )
+          )
+         )
+
+
+; program: $normalize_single_clause
+; args:
+; - clause Bool: A clause built with @cl.
+; return: >
+;    A clause logically equivalent to "clause", where leading double negations
+;    in disjuncts are removed.
+(program $normalize_single_clause ((formula Bool) (formulas Bool :list))
+         :signature (Bool) Bool
+         (
+          (
+           ($normalize_single_clause (@cl formula))
+
+           (@cl ($normalize_formula formula))
+           )
+
+          (; { literals != false }
+           ($normalize_single_clause (@cl formula formulas))
+
+           ($f_list_cons @cl ($normalize_formula formula) 
+                         ($normalize_single_clause formulas))
+           )
+
+          ;; (
+          ;;  ($normalize_single_clause false)
+
+          ;;  @empty_cl
+          ;;  )
+
+          (
+           ($normalize_single_clause @empty_cl)
+
+           @empty_cl
+           )
+          )
+         )
+
+; program: $normalize_clauses
+; args:
+; - clauses Bool: And-list of clauses.
+; return: >
+;    An and-list of clauses logically equivalent to "clauses", where each single
+;    "clause" is normalized, according to $normalize_single_clause.
+(program $normalize_clauses ((clause Bool) (clauses Bool :list))
+         :signature (Bool) Bool
+         (
+          (
+           ($normalize_clauses (and clause))
+           
+           ($normalize_single_clause clause)
+           )
+
+          ( ; { clauses != true }
+           ($normalize_clauses (and clause clauses))
+
+           ($f_list_cons and ($normalize_single_clause clause)
+                         ($normalize_clauses clauses))
+           )
+
+          ;; (
+          ;;  ($normalize_clauses true)
+
+          ;;  true
+          ;;  )
+          )
+         )
+
 ; program: $clause_contains_pivot
 ; args:
 ; - clause Bool: Clause within which we want to search for "pivot".
 ; - pivot Bool: Pivot to search within "clause".
 ; - $clause_contains_pivot nil:
 ; return: A bool indicating if "pivot" is contained within "clause".
+; note: PRE : { "pivot" is normalized
+;                && 
+;               "clause" is normalized }
 (program $clause_contains_pivot ((hd Bool) (tail Bool :list) 
-                                               (pivot Bool))
+                                 (pivot Bool))
          :signature (Bool Bool) Bool
          (
           (
+           ($clause_contains_pivot (@cl pivot) pivot)
+
+           true
+           )
+
+          (; {tail != false}
            ($clause_contains_pivot (@cl pivot tail) pivot)
 
            true
            )
 
-          (; { hd <> pivot }
+          (; { hd != pivot }
+           ($clause_contains_pivot (@cl hd) pivot)
+
+           false
+           )
+
+          (; { hd != pivot, pivot != false }
            ($clause_contains_pivot (@cl hd tail) pivot)
 
            ($clause_contains_pivot tail pivot)
            )
 
           (
-           ($clause_contains_pivot false pivot)
+           ($clause_contains_pivot @empty_cl pivot)
 
            false
            )
+
+          ;; (
+          ;;  ($clause_contains_pivot false pivot)
+
+          ;;  false
+          ;;  )
            )
          )
 
@@ -79,99 +184,210 @@
 ; - pivot Bool: Pivot literal contained in "clause".
 ; - clause Bool: Clause containing the pivot.
 ; return: The clause obtained from removing "pivot" from "clause".
-; note: PRE : { "pivot" is contained in "clause" }
+; note: PRE : { "pivot" is contained in "clause" 
+;                && 
+;               "pivot" is normalized
+;                && 
+;               "clause" is normalized }
 (program $remove_pivot_from_clause ((hd Bool) (tail Bool :list) 
                                       (pivot Bool))
          :signature (Bool Bool) Bool
          (
           (
+           ($remove_pivot_from_clause pivot (@cl pivot))
+
+           @empty_cl
+           )
+
+          (; { tail != false }
            ($remove_pivot_from_clause pivot (@cl pivot tail))
 
            tail
            )
 
-          (; { hd <> pivot }
+          ;; (; { hd != pivot }
+          ;;  ($remove_pivot_from_clause pivot (@cl hd))
+
+          ;;  (@cl hd)
+          ;;  )
+
+          (; { hd != pivot, tail != false }
            ($remove_pivot_from_clause pivot (@cl hd tail))
 
-           ($f_list_cons @cl 
-                         hd 
+           ; $remove_pivot_from_clause could return @empty_cl,
+           ; we need to resort to $cl_disjunct semantics to
+           ; build the result clause.
+           ($cl_disjunct (@cl hd)
                          ($remove_pivot_from_clause pivot tail))
            )
           )
          )
 
-; program: $find_and_remove_pivot_from_clause
+; program: $find_and_remove_pivot_from_clauses
 ; args:
 ; - pivot Bool: >
 ;   Pivot to be found and removed from the corresponding clause, if it exists.
 ; - clauses Bool: And-list of clauses.
 ; return: The clause containing "pivot", without "pivot" itself.
-; note: PRE : { "pivot" is contained in some clause from "clauses" }
-(program $find_and_remove_pivot_from_clause ((clause Bool) (clauses Bool :list) 
+; note: PRE : { "pivot" is contained in some clause from "clauses"
+;                && 
+;               "pivot" is normalized
+;                && 
+;               "clause" is normalized }
+(program $find_and_remove_pivot_from_clauses ((clause Bool) (clauses Bool :list) 
                                                (pivot Bool))
          :signature (Bool Bool) Bool
          (
-          (
-           ($find_and_remove_pivot_from_clause pivot (and clause clauses))
+          (; By pre, "clause" should contain "pivot".
+           ($find_and_remove_pivot_from_clauses pivot (and clause))
+           
+           ($remove_pivot_from_clause pivot clause)
+           )
+
+          (; {clauses != true}
+           ($find_and_remove_pivot_from_clauses pivot (and clause clauses))
 
            (eo::ite ($clause_contains_pivot clause pivot)
 
-                  ($remove_pivot_from_clause pivot clause)
+                    ($remove_pivot_from_clause pivot clause)
+                    
+                    ($find_and_remove_pivot_from_clauses pivot clauses)
+                    )
+           )
 
-                  ($find_and_remove_pivot_from_clause pivot clauses)
-                  )
+          (; By pre, "clause" should contain "pivot".
+           ; { clause is just a single @cl clause }
+           ($find_and_remove_pivot_from_clauses pivot clause)
+
+           ($remove_pivot_from_clause pivot clause)
            )
           )
 )
 
-; program: $check_resolution
+; program: $check_resolution_with_normalized_clauses 
 ; args:
-; - $check_resolution nil:
 ; - clauses Bool: And-list of normalized clauses (double negation is simplified).
-; return:
-(program $check_resolution ((clauses Bool) (pivot @VarList) (pivots @VarList :list)
+; - pivots @VarList: A list of pivots used during resolution.
+; - conclusion Bool: Conclusion provided to the rule.
+; return: >
+;   A boolean indicating if "conclusion" is a resolvent that can be
+;   obtained from applying resolution over "clauses", using the pivots
+;   contained in "pivots", in the same order of their appearance in the list.
+; note: PRE : { "clauses" are normalized: double negation is simplified }
+(program $check_resolution_with_normalized_clauses  ((clauses Bool)
+                                                     (polarity Bool)
+                                                     (pivot Bool) (pivots @VarList :list)
                             (conclusion Bool))
   (Bool @VarList Bool) Bool
   (
-   (; TODO: Still don't know the purpose of these "false" pivots
-    ($check_resolution clauses (@varlist false pivots) conclusion)
+   ;; (; TODO: Still don't know the purpose of these "false" pivots
+   ;;  ($check_resolution_with_normalized_clauses clauses (@varlist false pivots)
+   ;;                                             conclusion)
     
-    ($check_resolution clauses pivots conclusion)
-    )
+   ;;  ($check_resolution_with_normalized_clauses clauses pivots conclusion)
+   ;;  )
 
-   (; TODO: Sometimes with might get a pivot that is in its negated form
-    ($check_resolution clauses (@varlist pivot pivots) conclusion)
+   (; TODO: Sometimes we might get a pivot that is in its negated form
+    ($check_resolution_with_normalized_clauses clauses (@varlist pivot polarity pivots)
+                                               conclusion)
 
-    (eo::define 
+    (eo::define
+     
      (
-      (new_clause 
-       ($f_list_cons @cl
-                     ($find_and_remove_pivot_from_clause pivot clauses)
-                     ($f_list_cons @cl
-                                   ($find_and_remove_pivot_from_clause (not pivot) clauses)
-                                   false)))
+      (clause_without_pivot
+       ;; TODO: not being able to save normalized pivot
+       ;; We normalize the result to remove repeated occurrences of "false"
+       ;; ($normalize_single_clause
+        ($find_and_remove_pivot_from_clauses ($normalize_formula pivot) clauses)
+       ;)
+       )
+
+      (clause_without_not_pivot
+       ;; ($normalize_single_clause
+        ($find_and_remove_pivot_from_clauses ($normalize_formula (not pivot)) 
+                                             clauses)
+       ;)
+       )
+
+      ;; TODO: cannot refer to previous variable clause_without_pivot
+      ;; (new_clause 
+      ;;  ($normalize_single_clause ($f_list_cons @cl 
+      ;;                                          clause_without_pivot
+      ;;                                          clause_without_not_pivot))
+      ;;  )
       )
 
      ; eo::define's body:
-     (eo::ite ($cl_equal new_clause conclusion)
+     (eo::ite ;; (eo::or ($cl_equal clause_without_pivot conclusion)
+              ;;         ($cl_equal clause_without_not_pivot conclusion))
+              ($cl_equal conclusion ($cl_disjunct clause_without_pivot
+                                                  clause_without_not_pivot))
 
               true
 
               ;; {not ($cl_equal new_clause conclusion) }
-              ($check_resolution ($f_list_cons and new_clause clauses) 
-                                 pivots conclusion)
+              ;; (@cl (eo::var "normalized pivot" (eo::typeof conclusion))
+              ;;      ($normalize_formula pivot)
+              ;;      (eo::var "conclusion" (eo::typeof conclusion))
+              ;;      conclusion
+              ;;      (eo::var "clause_without_pivot:" (eo::typeof conclusion))
+              ;;      clause_without_pivot
+              ;;      (eo::var "clause_without_not_pivot:" (eo::typeof conclusion))
+              ;;      clause_without_not_pivot                                      
+              ;;      (eo::var "new_clause:" (eo::typeof conclusion))
+              ;;      ($cl_disjunct clause_without_pivot
+              ;;                                     clause_without_not_pivot)
+
+              ($check_resolution_with_normalized_clauses
+               ($f_list_cons and 
+                             ($cl_disjunct clause_without_pivot
+                                                  clause_without_not_pivot)
+                             clauses)
+               pivots conclusion)
+              ;)
               )
      )
     )
 
    (
-    ($check_resolution clauses @varlist.nil conclusion)
+    ($check_resolution_with_normalized_clauses clauses @varlist.nil conclusion)
 
     false
     )
    )
 )
 
+; program: $check_resolution
+; args:
+; - clauses Bool: And-list of clauses.
+; - pivots @VarList: A list of pivots used during resolution.
+; - conclusion Bool: Conclusion provided to the rule.
+; return: >
+;   A boolean indicating if "conclusion" is a resolvent that can be
+;   obtained from applying chain resolution over "clauses", using the pivots
+;   contained in "pivots", in the same order of their appearance in the list.
+(program $check_resolution ((clauses Bool) (pivots @VarList)
+                            (conclusion Bool))
+  (Bool @VarList Bool) Bool
+  (
+   (
+    ($check_resolution clauses pivots conclusion)
+
+    ($check_resolution_with_normalized_clauses 
+     ($normalize_clauses clauses) pivots conclusion)
+    )
+   )
+)
+
+; rule: th_resolution
+; implements: TODO?
+; premises:
+; - premises Bool:
+; - conclusion Bool:
+; - pivots @VarList:
+; args:
+; requires:
+; conclusion:
 (declare-rule th_resolution ((premises Bool) (conclusion Bool) (pivots @VarList))
   :premise-list premises and
   :args (pivots)
@@ -179,7 +395,19 @@
   :conclusion-explicit conclusion
 )
 
-;TRUST
+;-------------
+; Rule 7: resolution
+;-------------
+
+; rule: resolution
+; implements: TODO?
+; premises:
+; - premises Bool:
+; - conclusion Bool:
+; - pivots @VarList:
+; args:
+; requires:
+; conclusion:
 (declare-rule resolution ((premises Bool) (conclusion Bool) (pivots @VarList))
   :premise-list premises and
   :args (pivots)
@@ -578,7 +806,7 @@
                          @varlist.nil)
            )
 
-          (; { tail <> @varlist.nil }
+          (; { tail != @varlist.nil }
            ($check_sko_ex_build_skolem_vars choice_body (@varlist x tail))
 
            ($f_list_cons @varlist 
@@ -589,7 +817,7 @@
                          ($check_sko_ex_build_skolem_vars choice_body tail))
            )
 
-          (; { tail <> @varlist.nil }
+          (; { tail != @varlist.nil }
            ($check_sko_ex_build_skolem_vars choice_body @varlist.nil)
 
            @varlist.nil
@@ -673,7 +901,7 @@
   :args (old_context)
   :requires ((($check_sko_ex old_context new_context (@cl (= phi psi))
                              (@cl (= (exists existential_vars phi) psi))) true))
-  :conclusion (@cl (= (exists existential_vars phi) psi))
+  :conclusion-explicit (@cl (= (exists existential_vars phi) psi))
 )
 
 ;TODO
@@ -824,14 +1052,14 @@
     t1
     )
 
-    (; { eqs <> true}
+    (; { eqs != true}
      ; case (and (@cl (= t1 t2) false) eqs)
      ($last_eq_right (and (@cl (= t1 t2)) eqs) t1) 
 
      ($last_eq_right eqs t2)
      )
 
-    (; { eqs <> true}
+    (; { eqs != true}
      ; case (and (@cl (= t1 t2) false) eqs)
      ($last_eq_right (and (@cl (= t1 t2)) eqs) t2)
 
@@ -852,14 +1080,14 @@
      t1
      )
 
-    (; { eqs <> true}
+    (; { eqs != true}
      ; case (and (= t1 t2) eqs)
      ($last_eq_right (and (= t1 t2) eqs) t1)
      
      ($last_eq_right eqs t2)
      )
 
-    (; { eqs <> true}
+    (; { eqs != true}
      ; case (and (= t1 t2) eqs)
      ($last_eq_right (and (= t1 t2) eqs) t2)
      
@@ -893,13 +1121,13 @@
     (= t1 t2)
     )
 
-   (; { eqs <> true }
+   (; { eqs != true }
     ($make_trans (and (@cl (= t1 t2)) eqs) t1) 
     
     (= t1 ($last_eq_right eqs t2))
     )
 
-   (; { eqs <> true }
+   (; { eqs != true }
     ($make_trans (and (@cl (= t1 t2)) eqs) t2) 
     
     (= t2 ($last_eq_right eqs t1))

--- a/signature/alethe.eo
+++ b/signature/alethe.eo
@@ -40,24 +40,150 @@
   :conclusion-explicit (@cl (not (not (not phi))) phi)
 )
 
-; TODO
-(program $check_resolution ((Cs Bool) (CL Bool))
-  (Bool Bool) Bool
-  (
-   (($check_resolution Cs CL) true)
-  )
+;-------------
+; Rule 6: th_resolution
+;-------------
+
+; program: $clause_contains_pivot
+; args:
+; - clause Bool: Clause within which we want to search for "pivot".
+; - pivot Bool: Pivot to search within "clause".
+; - $clause_contains_pivot nil:
+; return: A bool indicating if "pivot" is contained within "clause".
+(program $clause_contains_pivot ((hd Bool) (tail Bool :list) 
+                                               (pivot Bool))
+         :signature (Bool Bool) Bool
+         (
+          (
+           ($clause_contains_pivot (@cl pivot tail) pivot)
+
+           true
+           )
+
+          (; { hd <> pivot }
+           ($clause_contains_pivot (@cl hd tail) pivot)
+
+           ($clause_contains_pivot tail pivot)
+           )
+
+          (
+           ($clause_contains_pivot false pivot)
+
+           false
+           )
+           )
+         )
+
+; program: $remove_pivot_from_clause
+; args:
+; - pivot Bool: Pivot literal contained in "clause".
+; - clause Bool: Clause containing the pivot.
+; return: The clause obtained from removing "pivot" from "clause".
+; note: PRE : { "pivot" is contained in "clause" }
+(program $remove_pivot_from_clause ((hd Bool) (tail Bool :list) 
+                                      (pivot Bool))
+         :signature (Bool Bool) Bool
+         (
+          (
+           ($remove_pivot_from_clause pivot (@cl pivot tail))
+
+           tail
+           )
+
+          (; { hd <> pivot }
+           ($remove_pivot_from_clause pivot (@cl hd tail))
+
+           ($f_list_cons @cl 
+                         hd 
+                         ($remove_pivot_from_clause pivot tail))
+           )
+          )
+         )
+
+; program: $find_and_remove_pivot_from_clause
+; args:
+; - pivot Bool: >
+;   Pivot to be found and removed from the corresponding clause, if it exists.
+; - clauses Bool: And-list of clauses.
+; return: The clause containing "pivot", without "pivot" itself.
+; note: PRE : { "pivot" is contained in some clause from "clauses" }
+(program $find_and_remove_pivot_from_clause ((clause Bool) (clauses Bool :list) 
+                                               (pivot Bool))
+         :signature (Bool Bool) Bool
+         (
+          (
+           ($find_and_remove_pivot_from_clause pivot (and clause clauses))
+
+           (eo::ite ($clause_contains_pivot clause pivot)
+
+                  ($remove_pivot_from_clause pivot clause)
+
+                  ($find_and_remove_pivot_from_clause pivot clauses)
+                  )
+           )
+          )
 )
 
-(declare-rule th_resolution ((Cs Bool) (conclusion Bool))
-  :premise-list Cs and
-  :requires ((($check_resolution Cs conclusion) true))
+; program: $check_resolution
+; args:
+; - $check_resolution nil:
+; - clauses Bool: And-list of normalized clauses (double negation is simplified).
+; return:
+(program $check_resolution ((clauses Bool) (pivot @VarList) (pivots @VarList :list)
+                            (conclusion Bool))
+  (Bool @VarList Bool) Bool
+  (
+   (; TODO: Still don't know the purpose of these "false" pivots
+    ($check_resolution clauses (@varlist false pivots) conclusion)
+    
+    ($check_resolution clauses pivots conclusion)
+    )
+
+   (; TODO: Sometimes with might get a pivot that is in its negated form
+    ($check_resolution clauses (@varlist pivot pivots) conclusion)
+
+    (eo::define 
+     (
+      (new_clause 
+       ($f_list_cons @cl
+                     ($find_and_remove_pivot_from_clause pivot clauses)
+                     ($f_list_cons @cl
+                                   ($find_and_remove_pivot_from_clause (not pivot) clauses)
+                                   false)))
+      )
+
+     ; eo::define's body:
+     (eo::ite ($cl_equal new_clause conclusion)
+
+              true
+
+              ;; {not ($cl_equal new_clause conclusion) }
+              ($check_resolution ($f_list_cons and new_clause clauses) 
+                                 pivots conclusion)
+              )
+     )
+    )
+
+   (
+    ($check_resolution clauses @varlist.nil conclusion)
+
+    false
+    )
+   )
+)
+
+(declare-rule th_resolution ((premises Bool) (conclusion Bool) (pivots @VarList))
+  :premise-list premises and
+  :args (pivots)
+  :requires ((($check_resolution premises pivots conclusion) true))
   :conclusion-explicit conclusion
 )
 
 ;TRUST
-(declare-rule resolution ((Cs Bool) (conclusion Bool))
-  :premise-list Cs and
-  :requires ((($check_resolution Cs conclusion) true))
+(declare-rule resolution ((premises Bool) (conclusion Bool) (pivots @VarList))
+  :premise-list premises and
+  :args (pivots)
+  :requires ((($check_resolution premises pivots conclusion) true))
   :conclusion-explicit conclusion
 )
 

--- a/signature/alethe.eo
+++ b/signature/alethe.eo
@@ -10,8 +10,8 @@
 ;   This models the following (taken from the standard spec.):
 ;   "A proof checker must not accept as valid a proof that contains this
 ;     rule even if the checker can somehow check this rule."
-(declare-rule hole ((conclusion Bool :list))
-  :conclusion-explicit (@cl conclusion)
+(declare-rule hole ((hd Bool) (tail Bool :list))
+  :conclusion-explicit (@cl hd tail)
   :sorry
 )
 

--- a/signature/alethe.eo
+++ b/signature/alethe.eo
@@ -44,17 +44,22 @@
 ; Rule 6: th_resolution
 ;-------------
 
-(program $normalize_formula ((formula Bool))
+; program: $remove_double_negation
+; args:
+; - formula Bool: An arbitrary formula.
+; return: >
+;   A formula equivalent to "formula", with leading double negations cancelled.
+(program $remove_double_negation ((formula Bool))
          :signature (Bool) Bool
          (
           (
-           ($normalize_formula (not (not formula)))
+           ($remove_double_negation (not (not formula)))
 
            formula
            )
 
           (; { "formula" does not begin with a double negation }
-           ($normalize_formula formula)
+           ($remove_double_negation formula)
 
            formula
            )
@@ -73,21 +78,15 @@
           (
            ($normalize_single_clause (@cl formula))
 
-           (@cl ($normalize_formula formula))
+           (@cl ($remove_double_negation formula))
            )
 
           (; { literals != false }
            ($normalize_single_clause (@cl formula formulas))
 
-           ($f_list_cons @cl ($normalize_formula formula) 
+           ($f_list_cons @cl ($remove_double_negation formula) 
                          ($normalize_single_clause formulas))
            )
-
-          ;; (
-          ;;  ($normalize_single_clause false)
-
-          ;;  @empty_cl
-          ;;  )
 
           (
            ($normalize_single_clause @empty_cl)
@@ -174,19 +173,11 @@
                                                (pivot Bool))
          :signature (Bool Bool) Bool
          (
-          ;; (; By pre, "clause" should contain "pivot".
-          ;;  ($find_and_remove_pivot_from_clauses pivot (and clause))
-           
-          ;;  ($f_list_remove_elem @cl clause @empty_cl pivot)
-          ;;  ;; ($remove_pivot_from_clause pivot clause)
-          ;;  )
-
           (; {clauses != true}
            ($find_and_remove_pivot_from_clauses pivot (and clause clauses))
 
            (eo::ite ($f_list_contains_elem @cl pivot clause)
 
-                    ;; ($f_list_remove_elem @cl clause pivot @empty_cl)
                     ($remove_pivot_from_clause pivot clause)
                     
                     ($find_and_remove_pivot_from_clauses pivot clauses)
@@ -261,34 +252,48 @@
   (
    (; Carcara's elaboration indicates the pivots followed by their "polarity": in 
     ; this case, true means that "pivot" appears exactly as it is, in some clause.
-    ($check_resolution_with_normalized_clauses clauses (@varlist pivot true pivots)
+    ($check_resolution_with_normalized_clauses clauses (@varlist pivot polarity 
+                                                                 pivots)
                                                conclusion)
 
     (eo::define
      (
-      (normalized_pivot ($normalize_formula pivot))
+      (normalized_pivot ($remove_double_negation pivot))
 
-      (normalized_negated_pivot ($normalize_formula (not pivot)))
+      (normalized_negated_pivot ($remove_double_negation (not pivot)))
       )
 
     (eo::define
      
      (
       (single_clause_without_pivot
-       ($find_and_remove_pivot_from_clauses normalized_pivot clauses)
+       ($find_and_remove_pivot_from_clauses 
+        (eo::ite polarity 
+                 normalized_pivot
+                 normalized_negated_pivot) clauses)
        )
 
-      (clauses_without_pivot ($return_untouched_clauses normalized_pivot clauses))
+      (clauses_without_pivot ($return_untouched_clauses 
+                              (eo::ite polarity 
+                                       normalized_pivot
+                                       normalized_negated_pivot) clauses))
       )
 
      (eo::define
       (
        (single_clause_without_not_pivot
-        ($find_and_remove_pivot_from_clauses normalized_negated_pivot clauses_without_pivot)
+        ($find_and_remove_pivot_from_clauses 
+         (eo::ite polarity 
+                  normalized_negated_pivot
+                  normalized_pivot)
+         clauses_without_pivot)
         )
 
-       (clauses_without_not_pivot ($return_untouched_clauses normalized_negated_pivot
-                                                             clauses_without_pivot))
+       (clauses_without_not_pivot ($return_untouched_clauses 
+                                   (eo::ite polarity 
+                                            normalized_negated_pivot
+                                            normalized_pivot)
+                                   clauses_without_pivot))
       )
 
       (eo::define
@@ -310,58 +315,6 @@
               )
               )
      )))
-    )
-
-   (; Carcara's elaboration indicates the pivots followed by their "polarity": in 
-    ; this case, false means that "pivot" appears as "not pivot", in some clause.
-    ($check_resolution_with_normalized_clauses clauses (@varlist pivot false pivots)
-                                               conclusion)
-
-    (eo::define
-     (
-      (normalized_pivot ($normalize_formula pivot))
-
-      (normalized_negated_pivot ($normalize_formula (not pivot)))
-      )
-
-    (eo::define
-     
-     (
-      (single_clause_without_pivot
-       ($find_and_remove_pivot_from_clauses normalized_negated_pivot clauses)
-       )
-
-      (clauses_without_pivot ($return_untouched_clauses normalized_negated_pivot clauses))
-      )
-
-     (eo::define
-      (
-       (single_clause_without_not_pivot
-        ($find_and_remove_pivot_from_clauses normalized_pivot clauses_without_pivot)
-        )
-
-       (clauses_without_not_pivot ($return_untouched_clauses normalized_pivot
-                                                             clauses_without_pivot))
-      )
-
-      (eo::define
-       (
-        (new_clause ($cl_disjunct single_clause_without_pivot
-                                  single_clause_without_not_pivot))
-        )
-
-     ; eo::define's body:
-     (eo::ite ($cl_equal conclusion new_clause)
-
-              true
-
-              ;; { not ($cl_equal conclusion new_clause) }
-              ($check_resolution_with_normalized_clauses
-               ($f_list_cons and new_clause
-                             clauses_without_not_pivot)
-               pivots conclusion)
-              )
-     ))))
     )
 
    (

--- a/signature/alethe.eo
+++ b/signature/alethe.eo
@@ -61,7 +61,6 @@
           )
          )
 
-
 ; program: $normalize_single_clause
 ; args:
 ; - clause Bool: A clause built with @cl.
@@ -119,64 +118,7 @@
            ($f_list_cons and ($normalize_single_clause clause)
                          ($normalize_clauses clauses))
            )
-
-          ;; (
-          ;;  ($normalize_clauses true)
-
-          ;;  true
-          ;;  )
           )
-         )
-
-; program: $clause_contains_pivot
-; args:
-; - clause Bool: Clause within which we want to search for "pivot".
-; - pivot Bool: Pivot to search within "clause".
-; - $clause_contains_pivot nil:
-; return: A bool indicating if "pivot" is contained within "clause".
-; note: PRE : { "pivot" is normalized
-;                && 
-;               "clause" is normalized }
-(program $clause_contains_pivot ((hd Bool) (tail Bool :list) 
-                                 (pivot Bool))
-         :signature (Bool Bool) Bool
-         (
-          (
-           ($clause_contains_pivot (@cl pivot) pivot)
-
-           true
-           )
-
-          (; {tail != false}
-           ($clause_contains_pivot (@cl pivot tail) pivot)
-
-           true
-           )
-
-          (; { hd != pivot }
-           ($clause_contains_pivot (@cl hd) pivot)
-
-           false
-           )
-
-          (; { hd != pivot, pivot != false }
-           ($clause_contains_pivot (@cl hd tail) pivot)
-
-           ($clause_contains_pivot tail pivot)
-           )
-
-          (
-           ($clause_contains_pivot @empty_cl pivot)
-
-           false
-           )
-
-          ;; (
-          ;;  ($clause_contains_pivot false pivot)
-
-          ;;  false
-          ;;  )
-           )
          )
 
 ; program: $remove_pivot_from_clause
@@ -205,12 +147,6 @@
            tail
            )
 
-          ;; (; { hd != pivot }
-          ;;  ($remove_pivot_from_clause pivot (@cl hd))
-
-          ;;  (@cl hd)
-          ;;  )
-
           (; { hd != pivot, tail != false }
            ($remove_pivot_from_clause pivot (@cl hd tail))
 
@@ -238,17 +174,19 @@
                                                (pivot Bool))
          :signature (Bool Bool) Bool
          (
-          (; By pre, "clause" should contain "pivot".
-           ($find_and_remove_pivot_from_clauses pivot (and clause))
+          ;; (; By pre, "clause" should contain "pivot".
+          ;;  ($find_and_remove_pivot_from_clauses pivot (and clause))
            
-           ($remove_pivot_from_clause pivot clause)
-           )
+          ;;  ($f_list_remove_elem @cl clause @empty_cl pivot)
+          ;;  ;; ($remove_pivot_from_clause pivot clause)
+          ;;  )
 
           (; {clauses != true}
            ($find_and_remove_pivot_from_clauses pivot (and clause clauses))
 
-           (eo::ite ($clause_contains_pivot clause pivot)
+           (eo::ite ($f_list_contains_elem @cl pivot clause)
 
+                    ;; ($f_list_remove_elem @cl clause pivot @empty_cl)
                     ($remove_pivot_from_clause pivot clause)
                     
                     ($find_and_remove_pivot_from_clauses pivot clauses)
@@ -259,7 +197,48 @@
            ; { clause is just a single @cl clause }
            ($find_and_remove_pivot_from_clauses pivot clause)
 
+           ;; ($f_list_remove_elem @cl clause pivot @empty_cl)
            ($remove_pivot_from_clause pivot clause)
+           )
+          )
+)
+
+; program: $return_untouched_clauses
+; args:
+; - pivot Bool: >
+;   Pivot that is being considered in the current binary resolution step.
+; - clauses Bool: And-list of clauses.
+; return: The And-list of clauses without the clause containing "pivot".
+; note: >
+;   PRE : { "pivot" is contained in some clause from "clauses"
+;           && 
+;           "pivot" is normalized
+;           && 
+;          "clause" is normalized }
+;   While this function repeats part of the work done by 
+;   $find_and_remove_pivot_from_clauses, it is added to simplify the task
+;   of identifying which are the remaining clauses upon which we must continue
+;   applying resolution steps
+(program $return_untouched_clauses ((clause Bool) (clauses Bool :list) 
+                                               (pivot Bool))
+         :signature (Bool Bool) Bool
+         (
+          (
+           ($return_untouched_clauses pivot (and clause clauses))
+
+           (eo::ite ($f_list_contains_elem @cl pivot clause)
+
+                    clauses
+                    
+                    ($f_list_cons and clause ($return_untouched_clauses pivot clauses))
+                    )
+           )
+
+          (; By pre, "clause" should contain "pivot".
+           ; { clause is just a single @cl clause }
+           ($return_untouched_clauses pivot clause)
+
+           true
            )
           )
 )
@@ -280,73 +259,109 @@
                             (conclusion Bool))
   (Bool @VarList Bool) Bool
   (
-   ;; (; TODO: Still don't know the purpose of these "false" pivots
-   ;;  ($check_resolution_with_normalized_clauses clauses (@varlist false pivots)
-   ;;                                             conclusion)
-    
-   ;;  ($check_resolution_with_normalized_clauses clauses pivots conclusion)
-   ;;  )
-
-   (; TODO: Sometimes we might get a pivot that is in its negated form
-    ($check_resolution_with_normalized_clauses clauses (@varlist pivot polarity pivots)
+   (; Carcara's elaboration indicates the pivots followed by their "polarity": in 
+    ; this case, true means that "pivot" appears exactly as it is, in some clause.
+    ($check_resolution_with_normalized_clauses clauses (@varlist pivot true pivots)
                                                conclusion)
+
+    (eo::define
+     (
+      (normalized_pivot ($normalize_formula pivot))
+
+      (normalized_negated_pivot ($normalize_formula (not pivot)))
+      )
 
     (eo::define
      
      (
-      (clause_without_pivot
-       ;; TODO: not being able to save normalized pivot
-       ;; We normalize the result to remove repeated occurrences of "false"
-       ;; ($normalize_single_clause
-        ($find_and_remove_pivot_from_clauses ($normalize_formula pivot) clauses)
-       ;)
+      (single_clause_without_pivot
+       ($find_and_remove_pivot_from_clauses normalized_pivot clauses)
        )
 
-      (clause_without_not_pivot
-       ;; ($normalize_single_clause
-        ($find_and_remove_pivot_from_clauses ($normalize_formula (not pivot)) 
-                                             clauses)
-       ;)
-       )
-
-      ;; TODO: cannot refer to previous variable clause_without_pivot
-      ;; (new_clause 
-      ;;  ($normalize_single_clause ($f_list_cons @cl 
-      ;;                                          clause_without_pivot
-      ;;                                          clause_without_not_pivot))
-      ;;  )
+      (clauses_without_pivot ($return_untouched_clauses normalized_pivot clauses))
       )
 
+     (eo::define
+      (
+       (single_clause_without_not_pivot
+        ($find_and_remove_pivot_from_clauses normalized_negated_pivot clauses_without_pivot)
+        )
+
+       (clauses_without_not_pivot ($return_untouched_clauses normalized_negated_pivot
+                                                             clauses_without_pivot))
+      )
+
+      (eo::define
+       (
+        (new_clause ($cl_disjunct single_clause_without_pivot
+                                  single_clause_without_not_pivot))
+        )
+
      ; eo::define's body:
-     (eo::ite ;; (eo::or ($cl_equal clause_without_pivot conclusion)
-              ;;         ($cl_equal clause_without_not_pivot conclusion))
-              ($cl_equal conclusion ($cl_disjunct clause_without_pivot
-                                                  clause_without_not_pivot))
+     (eo::ite ($cl_equal conclusion new_clause)
 
               true
 
               ;; {not ($cl_equal new_clause conclusion) }
-              ;; (@cl (eo::var "normalized pivot" (eo::typeof conclusion))
-              ;;      ($normalize_formula pivot)
-              ;;      (eo::var "conclusion" (eo::typeof conclusion))
-              ;;      conclusion
-              ;;      (eo::var "clause_without_pivot:" (eo::typeof conclusion))
-              ;;      clause_without_pivot
-              ;;      (eo::var "clause_without_not_pivot:" (eo::typeof conclusion))
-              ;;      clause_without_not_pivot                                      
-              ;;      (eo::var "new_clause:" (eo::typeof conclusion))
-              ;;      ($cl_disjunct clause_without_pivot
-              ;;                                     clause_without_not_pivot)
-
               ($check_resolution_with_normalized_clauses
-               ($f_list_cons and 
-                             ($cl_disjunct clause_without_pivot
-                                                  clause_without_not_pivot)
-                             clauses)
+               ($f_list_cons and new_clause
+                             clauses_without_not_pivot)
                pivots conclusion)
-              ;)
               )
-     )
+              )
+     )))
+    )
+
+   (; Carcara's elaboration indicates the pivots followed by their "polarity": in 
+    ; this case, false means that "pivot" appears as "not pivot", in some clause.
+    ($check_resolution_with_normalized_clauses clauses (@varlist pivot false pivots)
+                                               conclusion)
+
+    (eo::define
+     (
+      (normalized_pivot ($normalize_formula pivot))
+
+      (normalized_negated_pivot ($normalize_formula (not pivot)))
+      )
+
+    (eo::define
+     
+     (
+      (single_clause_without_pivot
+       ($find_and_remove_pivot_from_clauses normalized_negated_pivot clauses)
+       )
+
+      (clauses_without_pivot ($return_untouched_clauses normalized_negated_pivot clauses))
+      )
+
+     (eo::define
+      (
+       (single_clause_without_not_pivot
+        ($find_and_remove_pivot_from_clauses normalized_pivot clauses_without_pivot)
+        )
+
+       (clauses_without_not_pivot ($return_untouched_clauses normalized_pivot
+                                                             clauses_without_pivot))
+      )
+
+      (eo::define
+       (
+        (new_clause ($cl_disjunct single_clause_without_pivot
+                                  single_clause_without_not_pivot))
+        )
+
+     ; eo::define's body:
+     (eo::ite ($cl_equal conclusion new_clause)
+
+              true
+
+              ;; { not ($cl_equal conclusion new_clause) }
+              ($check_resolution_with_normalized_clauses
+               ($f_list_cons and new_clause
+                             clauses_without_not_pivot)
+               pivots conclusion)
+              )
+     ))))
     )
 
    (

--- a/signature/programs.eo
+++ b/signature/programs.eo
@@ -456,7 +456,9 @@
 ; args:
 ; - cl_1 Bool: A clause built with @cl.
 ; - cl_2 Bool: A clause built with @cl.
-; return: A clause representing the disjunction of "cl_1" and "cl_2".
+; return: >
+;   The clause formed by concatenating the literals of `cl_1` and `cl_2`, taking
+;   into account the semantics of `@empty_cl`.
 (program $cl_disjunct ((clause Bool) (left_disjunct Bool) (right_disjunct Bool)
                        (left_tail Bool :list) (right_tail Bool :list))
                        

--- a/signature/programs.eo
+++ b/signature/programs.eo
@@ -452,6 +452,47 @@
   )
 )
 
+; program: $cl_disjunct
+; args:
+; - cl_1 Bool: A clause built with @cl.
+; - cl_2 Bool: A clause built with @cl.
+; return: A clause representing the disjunction of "cl_1" and "cl_2".
+(program $cl_disjunct ((clause Bool) (left_disjunct Bool) (right_disjunct Bool)
+                       (left_tail Bool :list) (right_tail Bool :list))
+                       
+         :signature (Bool Bool) Bool
+         (
+          (
+           ($cl_disjunct @empty_cl clause)
+
+           clause
+           )
+
+          (; {clause != @empty_cl }
+           ($cl_disjunct clause @empty_cl)
+
+           clause
+           )
+
+          (
+           ($cl_disjunct (@cl left_disjunct) 
+                         (@cl right_disjunct right_tail))
+
+           (@cl left_disjunct right_disjunct right_tail)
+           )
+
+          (; { left_tail != false}
+           ($cl_disjunct (@cl left_disjunct left_tail) 
+                         (@cl right_disjunct right_tail))
+
+           ($f_list_cons @cl 
+                         left_disjunct 
+                         ($cl_disjunct left_tail
+                                       (@cl right_disjunct right_tail)))
+           )
+          )
+)
+
 ; program: convert_or_to_cl
 ; args:
 ; - or_clause Bool : >


### PR DESCRIPTION
This PR implements the "chain resolution" rule.
- It defines both Alethe rules ("resolution" and "th_resolution"), with the corresponding checker.
- Checking follows [Carcara's assumption ](https://github.com/ufmg-smite/carcara/blob/92fd8b4d2a9417bec5c3cf468fe874155db85d6c/carcara/src/resolution.rs#L111) that _"Only one pivot may be eliminated per clause"_. That is, we process each premise and intermediately generated clauses only once.
- We needed to implement a service called `$cl_disjunct`, to compute disjunctions of clauses that are built with `@cl`.
- Misc. stuff:
    - Minor changes in source code comments along `alethe.eo`.
    - Minor fix in rule `hole`, so it allows for clauses that are not just singletons.