### PR TITLE
Rules `not_simplify` and `or_simplify`

### DIFF
--- a/signature/rules/alethe.eo
+++ b/signature/rules/alethe.eo
@@ -2919,20 +2919,6 @@
   :conclusion-explicit conclusion
 )
 
-;TODO
-(program $check_not_simplify ((conclusion Bool))
-  :signature (Bool) Bool
-  (
-   (($check_not_simplify conclusion) true)
-  )
-)
-
-;TRUST
-(declare-rule not_simplify ((conclusion Bool))
-  :requires ((($check_not_simplify conclusion) true))
-  :conclusion-explicit conclusion
-)
-
 ;-------------
 ; Rule 75: implies_simplify
 ;-------------

--- a/signature/rules/alethe.eo
+++ b/signature/rules/alethe.eo
@@ -2905,20 +2905,6 @@
   :conclusion (@cl (= l r))
 )
 
-;TODO
-(program $check_or_simplify ((conclusion Bool))
-  :signature (Bool) Bool
-  (
-   (($check_or_simplify conclusion) true)
-  )
-)
-
-;TRUST
-(declare-rule or_simplify ((conclusion Bool))
-  :requires ((($check_or_simplify conclusion) true))
-  :conclusion-explicit conclusion
-)
-
 ;-------------
 ; Rule 75: implies_simplify
 ;-------------

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -4,10 +4,233 @@
 ; Rules that introduce tautologies.
 
 ;-----------------------
+; Rule 73: or_simplify
+;-----------------------
+
+; program: $remove_leading_negations
+; args:
+; - formula Bool: An arbitrary formula.
+; return: >
+;   The result from removing leading double negations from `formula`.
+(program $remove_leading_negations ((formula Bool))
+         :signature (Bool) Bool
+         (
+          (
+           ($remove_leading_negations (not (not formula)))
+
+           ($remove_leading_negations formula)
+           )
+
+          (; { `formula` does not begin with a double negation }
+           ($remove_leading_negations formula)
+
+           formula
+           )
+          )
+         )
+
+; program: $remove_leading_negations_in_disjuncts
+; args:
+; - disjunct Bool: An disjunct built with `or`.
+; return: >
+;   The result from removing leading double negations from each disjunct
+;   in `disjunct`.
+(program $remove_leading_negations_in_disjuncts ((disjunct Bool) (disjuncts Bool :list))
+         :signature (Bool) Bool
+         (
+          (
+           ($remove_leading_negations_in_disjuncts (or disjunct disjuncts))
+
+           ($f_list_cons or 
+                         ($remove_leading_negations disjunct)
+                         ($remove_leading_negations_in_disjuncts disjuncts))
+           )
+
+          (; { `formula` is not a disjunct }
+           ($remove_leading_negations_in_disjuncts false)
+
+           false
+           )
+          )
+         )
+
+; program: $or_simplify_small_step
+; args:
+; - formula Bool: A formula.
+; return: >
+;   The result from applying one of the following equivalence-preserving transformations:
+;   - ⊥∨ 𝜑 ∨ ⋯ ⇒ 𝜑 ∨ ⋯ 
+;   - 𝜑1 ∨ ⋯ ∨ 𝜑𝑛 ⇒ 𝜑1 ∨ ⋯ ∨ 𝜑𝑛′ where the right-hand side has some ⊥ literal removed.
+;   - 𝜑1 ∨ ⋯ ∨ 𝜑𝑛 ⇒ 𝜑1 ∨ ⋯ ∨ 𝜑𝑛′ where the right-hand side has some repeated literal removed.
+;   - ⊤ ∨ ⋯ ∨ 𝜑 𝑛 ⇒ ⊤
+;   - 𝜑𝑖 ∨ ⋯ ∨ 𝜑𝑗 ∨ ⋯ ∨ 𝜑𝑛 ⇒ ⊤ and 𝜑𝑖 , 𝜑𝑗 are such that one is the
+;     negation of the other formula
+; note: PRE : { $remove_leading_negations_in_disjuncts `formula` = `formula`}
+(program $or_simplify_small_step ((disjunct Bool) (disjuncts Bool :list))
+  :signature (Bool) Bool
+  (
+   (
+    ($or_simplify_small_step (or false disjuncts))
+
+    disjuncts
+    )
+
+   (
+    ($or_simplify_small_step (or true disjuncts))
+
+    true
+    )
+   
+   (
+    ($or_simplify_small_step (or (not disjunct) disjuncts))
+
+    (eo::ite ($eo_is_eq disjuncts false)
+
+             (not disjunct)
+
+              ; { not ($eo_is_eq disjuncts false) }
+             (eo::ite ($eo_is_eq disjuncts true)
+
+                      true
+
+                      ; { not ($eo_is_eq disjuncts true) }
+                      (eo::ite ($f_list_contains_elem or (not disjunct) disjuncts)
+
+                               disjuncts
+
+                               ; { not ($f_list_contains_elem or (not disjunct) disjuncts) }
+                               (eo::ite ($f_list_contains_elem or disjunct disjuncts)
+
+                                        ; We have a or (not disjunct) disjunct ... = true
+                                        true
+
+                                        ; { not ($f_list_contains_elem or disjunct disjuncts) }
+                                        (or (not disjunct) disjuncts)))))
+             )
+
+   ( ; { disjunct != true, false, not ... }
+    ($or_simplify_small_step (or disjunct disjuncts))
+
+    (eo::ite ($eo_is_eq disjuncts false)
+
+             disjunct
+
+             ; { not ($eo_is_eq disjuncts false) }
+             (eo::ite ($eo_is_eq disjuncts true)
+
+                      true
+
+                      ; { not ($eo_is_eq disjuncts true) }
+                      (eo::ite ($f_list_contains_elem or disjunct disjuncts)
+
+                               disjuncts
+
+                               ; { not ($f_list_contains_elem or disjunct disjuncts) }
+                               (eo::ite ($f_list_contains_elem or (not disjunct) disjuncts)
+
+                                        ; We have a or (not disjunct) disjunct ... = true
+                                        true
+
+                                        ; { not ($f_list_contains_elem or (not disjunct) disjuncts) }
+                                        (or disjunct disjuncts)))))
+    )
+
+   ( ; { disjunct != or ... }
+    ($or_simplify_small_step disjunct)
+
+    disjunct
+    )
+  )
+)
+
+; program: $or_simplify_rec
+; args:
+; - formula Bool: A formula.
+; return: >
+;   The result from applying the equivalence-preserving transformations described
+;   in `$or_simplify_small_step` until a fixed point is reached.
+; note: PRE : { $remove_leading_negations_in_disjuncts `formula` = `formula`}
+(program $or_simplify_rec ((disjunct Bool) (disjuncts Bool :list))
+  :signature (Bool) Bool
+  (
+   (
+    ($or_simplify_rec (or disjunct disjuncts))
+
+    (eo::define 
+
+     ((disjuncts_simplified ($or_simplify_rec disjuncts)))
+
+     (eo::ite ($eo_is_eq disjuncts_simplified disjuncts)
+
+              ; We continue reducing, right-to-left.
+              (eo::define 
+
+               ((whole_disjunct_simplified 
+
+                 ($or_simplify_small_step (or disjunct disjuncts))))
+
+               (eo::ite ($eo_is_eq whole_disjunct_simplified 
+                                   (or disjunct disjuncts))
+
+                        ; We reached to a fixed point.
+                        (or disjunct disjuncts)
+
+                        ; { not ($eo_is_eq whole_disjunct_simplified 
+                        ;                  (or disjunct disjuncts)) }
+                        ($or_simplify_rec whole_disjunct_simplified)))
+
+              ; { not ($eo_is_eq disjuncts_simplified disjuncts) }
+              ($or_simplify_rec 
+               ($f_list_cons or disjunct disjuncts_simplified))))
+    )
+
+   ( ; { disjunct != or ...}
+     ($or_simplify_rec disjunct)
+
+     disjunct
+     )
+    )
+  )
+
+; program: $check_or_simplify
+; args:
+; - lhs Bool: >
+;   The left-hand side of the equality in the conclusion passed to rule 
+;   `or_simplify`
+; - rhs: >
+;   The right-hand side of the equality in the conclusion passed to rule 
+;   `or_simplify`
+; return: >
+;   A boolean indicating if `lhs` can be reduced to `rhs` using 
+;   `$or_simplify_rec`.
+(program $check_or_simplify ((lhs Bool) (rhs Bool))
+  :signature (Bool Bool) Bool
+  (
+   (
+    ($check_or_simplify lhs rhs)
+
+    ($eo_is_eq ($or_simplify_rec ($remove_leading_negations_in_disjuncts lhs))
+
+               rhs)
+    )
+  )
+)
+
+; rule: not_simplify
+; requires: >
+;   For `lhs` to be reducible to `rhs` following the rules 
+;   in `$or_simplify_rec`.
+; conclusion-explicit: (@cl (= lhs rhs))
+(declare-rule or_simplify ((lhs Bool) (rhs Bool))
+  :requires ((($check_or_simplify lhs rhs) true))
+  :conclusion-explicit (@cl (= lhs rhs))
+)
+
+;-----------------------
 ; Rule 74: not_simplify
 ;-----------------------
 
-; program: $simplify_not_rec
+; program: $not_simplify_rec
 ; args:
 ; - psi Bool: A formula.
 ; return: >
@@ -16,29 +239,29 @@
 ;   - ¬(¬psi) ⇒ psi
 ;   - ¬⊥ ⇒ ⊤
 ;   - ¬⊤ ⇒ ⊥
-(program $simplify_not_rec ((psi Bool))
+(program $not_simplify_rec ((psi Bool))
   :signature (Bool) Bool
   (
    (
-    ($simplify_not_rec (not (not psi)))
+    ($not_simplify_rec (not (not psi)))
 
-    ($simplify_not_rec psi)
+    ($not_simplify_rec psi)
     )
 
    (
-    ($simplify_not_rec (not false))
+    ($not_simplify_rec (not false))
 
     true
     )
 
    (
-    ($simplify_not_rec (not true))
+    ($not_simplify_rec (not true))
 
     false
     )
 
    (; { psi does not being with double not, nor has the form (not false), (not true)}
-    ($simplify_not_rec psi)
+    ($not_simplify_rec psi)
 
     psi
     )
@@ -55,18 +278,23 @@
 ;   `not_simplify`
 ; return: >
 ;   A boolean indicating if `not_phi` can be reduced to `psi` using 
-;   `$simplify_not_rec`.
+;   `$not_simplify_rec`.
 (program $check_not_simplify ((not_phi Bool) (psi Bool))
   :signature (Bool Bool) Bool
   (
    (
     ($check_not_simplify not_phi psi) 
 
-    ($eo_is_eq ($simplify_not_rec not_phi) psi)
+    ($eo_is_eq ($not_simplify_rec not_phi) psi)
     )
   )
 )
 
+; rule: not_simplify
+; requires: >
+;   For `(not phi)` to be reducible to `psi` following the rules 
+;   in `$not_simplify_rec`.
+; conclusion-explicit: (@cl (= (not phi) psi))
 (declare-rule not_simplify ((phi Bool) (psi Bool))
   :requires ((($check_not_simplify (not phi) psi) true))
   :conclusion-explicit (@cl (= (not phi) psi))

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -58,10 +58,13 @@
 ; args:
 ; - formula Bool: A formula.
 ; return: >
-;   The result from applying one of the following equivalence-preserving transformations:
+;   The result from applying one of the following equivalence-preserving 
+;   transformations:
 ;   - ⊥∨ 𝜑 ∨ ⋯ ⇒ 𝜑 ∨ ⋯ 
-;   - 𝜑1 ∨ ⋯ ∨ 𝜑𝑛 ⇒ 𝜑1 ∨ ⋯ ∨ 𝜑𝑛′ where the right-hand side has some ⊥ literal removed.
-;   - 𝜑1 ∨ ⋯ ∨ 𝜑𝑛 ⇒ 𝜑1 ∨ ⋯ ∨ 𝜑𝑛′ where the right-hand side has some repeated literal removed.
+;   - 𝜑1 ∨ ⋯ ∨ 𝜑𝑛 ⇒ 𝜑1 ∨ ⋯ ∨ 𝜑𝑛′ where the right-hand side has some ⊥ literal 
+;     removed.
+;   - 𝜑1 ∨ ⋯ ∨ 𝜑𝑛 ⇒ 𝜑1 ∨ ⋯ ∨ 𝜑𝑛′ where the right-hand side has some repeated 
+;     literal removed.
 ;   - ⊤ ∨ ⋯ ∨ 𝜑 𝑛 ⇒ ⊤
 ;   - 𝜑𝑖 ∨ ⋯ ∨ 𝜑𝑗 ∨ ⋯ ∨ 𝜑𝑛 ⇒ ⊤ and 𝜑𝑖 , 𝜑𝑗 are such that one is the
 ;     negation of the other formula

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -1,6 +1,76 @@
 (include "../theories/theory.eo")
+(include "../programs/programs.eo")
 
 ; Rules that introduce tautologies.
+
+;-----------------------
+; Rule 74: not_simplify
+;-----------------------
+
+; program: $simplify_not_rec
+; args:
+; - psi Bool: A formula.
+; return: >
+;   The result from applying the following equivalence-preserving transformations until
+;   a fixed point is reached:
+;   - ¬(¬psi) ⇒ psi
+;   - ¬⊥ ⇒ ⊤
+;   - ¬⊤ ⇒ ⊥
+(program $simplify_not_rec ((psi Bool))
+  :signature (Bool) Bool
+  (
+   (
+    ($simplify_not_rec (not (not psi)))
+
+    ($simplify_not_rec psi)
+    )
+
+   (
+    ($simplify_not_rec (not false))
+
+    true
+    )
+
+   (
+    ($simplify_not_rec (not true))
+
+    false
+    )
+
+   (; { psi does not being with double not, nor has the form (not false), (not true)}
+    ($simplify_not_rec psi)
+
+    psi
+    )
+  )
+)
+
+; program: $check_not_simplify
+; args:
+; - not_phi Bool: >
+;   The left-hand side of the equality in the conclusion passed to rule 
+;   `not_simplify`
+; - psi Bool: >
+;   The right-hand side of the equality in the conclusion passed to rule 
+;   `not_simplify`
+; return: >
+;   A boolean indicating if `not_phi` can be reduced to `psi` using 
+;   `$simplify_not_rec`.
+(program $check_not_simplify ((not_phi Bool) (psi Bool))
+  :signature (Bool Bool) Bool
+  (
+   (
+    ($check_not_simplify not_phi psi) 
+
+    ($eo_is_eq ($simplify_not_rec not_phi) psi)
+    )
+  )
+)
+
+(declare-rule not_simplify ((phi Bool) (psi Bool))
+  :requires ((($check_not_simplify (not phi) psi) true))
+  :conclusion-explicit (@cl (= (not phi) psi))
+)
 
 ;-----------------------
 ; Rule 103: eq_symmetric

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -1,0 +1,15 @@
+(include "../theories/theory.eo")
+
+; Rules that introduce tautologies.
+
+;-----------------------
+; Rule 103: eq_symmetric
+;-----------------------
+
+; rule: eq_symmetric
+; conclusion-explicit: >
+;   Conclusion must have the form (@cl (= (= t1 t2) (= t2 t1))), for terms 
+;   t1 and t2 of arbitrary type.
+(declare-rule eq_symmetric ((A Type) (B Type) (t1 A) (t2 B))
+  :conclusion-explicit (@cl (= (= t1 t2) (= t2 t1)))
+)

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -60,12 +60,12 @@
 ; return: >
 ;   The result from applying one of the following equivalence-preserving 
 ;   transformations:
-;   - ⊥∨ 𝜑 ∨ ⋯ ⇒ 𝜑 ∨ ⋯ 
+;   - ⊥∨⋯∨⊥ ⇒ ⊥
 ;   - 𝜑1 ∨ ⋯ ∨ 𝜑𝑛 ⇒ 𝜑1 ∨ ⋯ ∨ 𝜑𝑛′ where the right-hand side has some ⊥ literal 
 ;     removed.
 ;   - 𝜑1 ∨ ⋯ ∨ 𝜑𝑛 ⇒ 𝜑1 ∨ ⋯ ∨ 𝜑𝑛′ where the right-hand side has some repeated 
 ;     literal removed.
-;   - ⊤ ∨ ⋯ ∨ 𝜑 𝑛 ⇒ ⊤
+;   - ⊤ ∨ ⋯ ∨ 𝜑𝑛 ⇒ ⊤
 ;   - 𝜑𝑖 ∨ ⋯ ∨ 𝜑𝑗 ∨ ⋯ ∨ 𝜑𝑛 ⇒ ⊤ and 𝜑𝑖 , 𝜑𝑗 are such that one is the
 ;     negation of the other formula
 ; note: PRE : { $remove_leading_negations_in_disjuncts `formula` = `formula`}
@@ -219,7 +219,7 @@
   )
 )
 
-; rule: not_simplify
+; rule: or_simplify
 ; requires: >
 ;   For `lhs` to be reducible to `rhs` following the rules 
 ;   in `$or_simplify_rec`.
@@ -239,7 +239,7 @@
 ; return: >
 ;   The result from applying the following equivalence-preserving transformations until
 ;   a fixed point is reached:
-;   - ¬(¬psi) ⇒ psi
+;   - ¬(¬ ᴪ) ⇒ ᴪ
 ;   - ¬⊥ ⇒ ⊤
 ;   - ¬⊤ ⇒ ⊥
 (program $not_simplify_rec ((psi Bool))

--- a/tests/rules/tests_tautologies.eo
+++ b/tests/rules/tests_tautologies.eo
@@ -1,0 +1,73 @@
+(include "../../signature/rules/tautologies.eo")
+(include "../unit_test_services.eo")
+
+
+; Unit tests for rules that introduce tautologies.
+
+;-------------
+; eq_symmetric
+;-------------
+
+; Some constants to build terms, for testing purposes.
+(declare-const a Int)
+(declare-const b Int)
+(declare-const c Real)
+(declare-const d Real)
+(declare-const S Type)
+(declare-const e S)
+(declare-const f S)
+(declare-const g (-> S S))
+
+; Arbitrary arith terms
+(step $test_$eq_symmetric
+      (@cl (= (= 1 2) (= 2 1)))
+      :rule eq_symmetric)
+
+(step $test_$eq_symmetric
+      (@cl (= (= 1.0 2.0) (= 2.0 1.0)))
+      :rule eq_symmetric)
+
+(step $test_$eq_symmetric
+      (@cl (= (= a b) (= b a)))
+      :rule eq_symmetric)
+
+(step $test_$eq_symmetric
+      (@cl (= (= (+ a 1) b) (= b (+ a 1))))
+      :rule eq_symmetric)
+
+(step $test_$eq_symmetric
+      (@cl (= (= (+ c 1) d) (= d (+ c 1))))
+      :rule eq_symmetric)
+
+; Boolean terms
+
+(step $test_$eq_symmetric
+      (@cl (= (= true false) (= false true)))
+      :rule eq_symmetric)
+
+(step $test_$eq_symmetric
+      (@cl (= (= (or true true) false) (= false (or true true))))
+      :rule eq_symmetric)
+
+(step $test_$eq_symmetric
+      (@cl (= (= (or true true) (and false true)) 
+              (= (and false true) (or true true))))
+      :rule eq_symmetric)
+
+; Arbitrary sorts
+
+(step $test_$eq_symmetric
+      (@cl (= (= e f) (= f e)))
+      :rule eq_symmetric)
+
+(step $test_$eq_symmetric
+      (@cl (= (= e e) (= e e)))
+      :rule eq_symmetric)
+
+(step $test_$eq_symmetric
+      (@cl (= (= (g e) e) (= e (g e))))
+      :rule eq_symmetric)
+
+(step $test_$eq_symmetric
+      (@cl (= (= (g e) (g (g f))) (= (g (g f)) (g e))))
+      :rule eq_symmetric)

--- a/tests/rules/tests_tautologies.eo
+++ b/tests/rules/tests_tautologies.eo
@@ -5,6 +5,51 @@
 ; Unit tests for rules that introduce tautologies.
 
 ;-------------
+; not_simplify
+;-------------
+
+; Some constants to build terms, for testing purposes.
+(declare-const a Bool)
+
+; Removing leading double negations
+(step $test_$not_simplify
+      (@cl (= (not (not true)) true))
+      :rule not_simplify)
+
+(step $test_$not_simplify
+      (@cl (= (not (not false)) false))
+      :rule not_simplify)
+
+(step $test_$not_simplify
+      (@cl (= (not (not a)) a))
+      :rule not_simplify)
+
+(step $test_$not_simplify
+      (@cl (= (not (not (not (not false)))) false))
+      :rule not_simplify)
+
+(step $test_$not_simplify
+      (@cl (= (not (not (not (not (not a))))) (not a)))
+      :rule not_simplify)
+
+; Negation over constants
+(step $test_$not_simplify
+      (@cl (= (not true) false))
+      :rule not_simplify)
+
+(step $test_$not_simplify
+      (@cl (= (not false) true))
+      :rule not_simplify)
+
+(step $test_$not_simplify
+      (@cl (= (not (not (not (not (not false))))) true))
+      :rule not_simplify)
+
+(step $test_$not_simplify
+      (@cl (= (not (not (not (not (not true))))) false))
+      :rule not_simplify)
+
+;-------------
 ; eq_symmetric
 ;-------------
 

--- a/tests/rules/tests_tautologies.eo
+++ b/tests/rules/tests_tautologies.eo
@@ -13,25 +13,25 @@
 (declare-const c Bool)
 
 ; First case of $or_simplify_rec
-(step $test_$or_simplify_rec true 
+(step $test_$or_simplify_rec_1 true 
       :rule $assert_eq 
       :args (($or_simplify_rec (or false false)) false))
 
 
 ; Second case of $or_simplify_rec
-(step $test_$or_simplify_rec true 
+(step $test_$or_simplify_rec_2 true 
       :rule $assert_eq 
       :args (($or_simplify_rec (or false a b false)) 
              ($f_list_cons or a b)))
 
-(step $test_$or_simplify_rec true 
+(step $test_$or_simplify_rec_3 true 
       :rule $assert_eq 
       :args (($or_simplify_rec (or false a b false c false)) 
              ($f_list_cons or a ($f_list_cons or b c))))
 
 
 ; Fourth case of $or_simplify_rec
-(step $test_$or_simplify_rec true 
+(step $test_$or_simplify_rec_4 true 
       :rule $assert_eq 
       :args (($or_simplify_rec (or a true false)) 
              true))
@@ -47,147 +47,147 @@
 (declare-const c Bool)
 
 ; First case of $or_simplify_rec
-(step $test_$or_simplify
+(step $test_$or_simplify_1
       (@cl (= false false))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_2
       (@cl (= (or false false) false))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_3
       (@cl (= (or false false false) false))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_4
       (@cl (= (or false false false false) false))
       :rule or_simplify)
 
 ; Second case of $or_simplify_rec
-(step $test_$or_simplify
+(step $test_$or_simplify_5
       (@cl (= (or a false) a))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_6
       (@cl (= (or false a) a))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_7
       (@cl (= (or false a false) a))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_8
       (@cl (= (or false false a false) a))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_9
       (@cl (= (or false false false a) a))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_10
       (@cl (= (or false a false b) 
               ($f_list_cons or a b)))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_11
       (@cl (= (or false a b c false) 
               ($f_list_cons or a ($f_list_cons or b c))))
       :rule or_simplify)
 
 ; Third case of $or_simplify_rec
-(step $test_$or_simplify
+(step $test_$or_simplify_12
       (@cl (= (or a a false) a))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_13
       (@cl (= (or a false a) a))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_14
       (@cl (= (or a false a false) a))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_15
       (@cl (= (or false a false a false) a))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_16
       (@cl (= (or false a a a) a))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_17
       (@cl (= (or false a b false a b) 
               ($f_list_cons or a b)))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_18
       (@cl (= (or false a b c c false a) 
               ($f_list_cons or b ($f_list_cons or c a))))
       :rule or_simplify)
 
 ; Fourth case of $or_simplify_rec
-(step $test_$or_simplify
+(step $test_$or_simplify_19
       (@cl (= (or a true) true))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_20
       (@cl (= (or a true a) true))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_21
       (@cl (= (or a false a true) true))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_22
       (@cl (= (or false a true a false) true))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_23
       (@cl (= (or false a a true) true))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_24
       (@cl (= (or false a b false true b) 
               true))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_25
       (@cl (= (or false a b c c true a) 
               true))
       :rule or_simplify)
 
 ; Fifth case of $or_simplify_rec
-(step $test_$or_simplify
+(step $test_$or_simplify_26
       (@cl (= (or (not a) a) 
               true))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_27
       (@cl (= (or a (not a)) 
               true))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_28
       (@cl (= (or a (not (not (not a))))
               true))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_29
       (@cl (= (or (not (not a)) (not (not (not a))))
               true))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_30
       (@cl (= (or (not (not a)) false (not (not (not a))))
               true))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_31
       (@cl (= (or (not (not (not (not a)))) false (not (not (not a))))
               true))
       :rule or_simplify)
 
-(step $test_$or_simplify
+(step $test_$or_simplify_32
       (@cl (= (or (not (not (not (not a)))) false (not (not (not a))) b)
               true))
       :rule or_simplify)
@@ -200,40 +200,40 @@
 (declare-const a Bool)
 
 ; Removing leading double negations
-(step $test_$not_simplify
+(step $test_$not_simplify_1
       (@cl (= (not (not true)) true))
       :rule not_simplify)
 
-(step $test_$not_simplify
+(step $test_$not_simplify_2
       (@cl (= (not (not false)) false))
       :rule not_simplify)
 
-(step $test_$not_simplify
+(step $test_$not_simplify_3
       (@cl (= (not (not a)) a))
       :rule not_simplify)
 
-(step $test_$not_simplify
+(step $test_$not_simplify_4
       (@cl (= (not (not (not (not false)))) false))
       :rule not_simplify)
 
-(step $test_$not_simplify
+(step $test_$not_simplify_5
       (@cl (= (not (not (not (not (not a))))) (not a)))
       :rule not_simplify)
 
 ; Negation over constants
-(step $test_$not_simplify
+(step $test_$not_simplify_6
       (@cl (= (not true) false))
       :rule not_simplify)
 
-(step $test_$not_simplify
+(step $test_$not_simplify_7
       (@cl (= (not false) true))
       :rule not_simplify)
 
-(step $test_$not_simplify
+(step $test_$not_simplify_8
       (@cl (= (not (not (not (not (not false))))) true))
       :rule not_simplify)
 
-(step $test_$not_simplify
+(step $test_$not_simplify_9
       (@cl (= (not (not (not (not (not true))))) false))
       :rule not_simplify)
 
@@ -252,55 +252,55 @@
 (declare-const g (-> S S))
 
 ; Arbitrary arith terms
-(step $test_$eq_symmetric
+(step $test_$eq_symmetric_1
       (@cl (= (= 1 2) (= 2 1)))
       :rule eq_symmetric)
 
-(step $test_$eq_symmetric
+(step $test_$eq_symmetric_2
       (@cl (= (= 1.0 2.0) (= 2.0 1.0)))
       :rule eq_symmetric)
 
-(step $test_$eq_symmetric
+(step $test_$eq_symmetric_3
       (@cl (= (= a b) (= b a)))
       :rule eq_symmetric)
 
-(step $test_$eq_symmetric
+(step $test_$eq_symmetric_4
       (@cl (= (= (+ a 1) b) (= b (+ a 1))))
       :rule eq_symmetric)
 
-(step $test_$eq_symmetric
+(step $test_$eq_symmetric_5
       (@cl (= (= (+ c 1) d) (= d (+ c 1))))
       :rule eq_symmetric)
 
 ; Boolean terms
 
-(step $test_$eq_symmetric
+(step $test_$eq_symmetric_6
       (@cl (= (= true false) (= false true)))
       :rule eq_symmetric)
 
-(step $test_$eq_symmetric
+(step $test_$eq_symmetric_7
       (@cl (= (= (or true true) false) (= false (or true true))))
       :rule eq_symmetric)
 
-(step $test_$eq_symmetric
+(step $test_$eq_symmetric_8
       (@cl (= (= (or true true) (and false true)) 
               (= (and false true) (or true true))))
       :rule eq_symmetric)
 
 ; Arbitrary sorts
 
-(step $test_$eq_symmetric
+(step $test_$eq_symmetric_9
       (@cl (= (= e f) (= f e)))
       :rule eq_symmetric)
 
-(step $test_$eq_symmetric
+(step $test_$eq_symmetric_10
       (@cl (= (= e e) (= e e)))
       :rule eq_symmetric)
 
-(step $test_$eq_symmetric
+(step $test_$eq_symmetric_11
       (@cl (= (= (g e) e) (= e (g e))))
       :rule eq_symmetric)
 
-(step $test_$eq_symmetric
+(step $test_$eq_symmetric_12
       (@cl (= (= (g e) (g (g f))) (= (g (g f)) (g e))))
       :rule eq_symmetric)

--- a/tests/rules/tests_tautologies.eo
+++ b/tests/rules/tests_tautologies.eo
@@ -5,6 +5,194 @@
 ; Unit tests for rules that introduce tautologies.
 
 ;-------------
+; $or_simplify_rec
+;-------------
+; Some constants to build terms, for testing purposes.
+(declare-const a Bool)
+(declare-const b Bool)
+(declare-const c Bool)
+
+; First case of $or_simplify_rec
+(step $test_$or_simplify_rec true 
+      :rule $assert_eq 
+      :args (($or_simplify_rec (or false false)) false))
+
+
+; Second case of $or_simplify_rec
+(step $test_$or_simplify_rec true 
+      :rule $assert_eq 
+      :args (($or_simplify_rec (or false a b false)) 
+             ($f_list_cons or a b)))
+
+(step $test_$or_simplify_rec true 
+      :rule $assert_eq 
+      :args (($or_simplify_rec (or false a b false c false)) 
+             ($f_list_cons or a ($f_list_cons or b c))))
+
+
+; Fourth case of $or_simplify_rec
+(step $test_$or_simplify_rec true 
+      :rule $assert_eq 
+      :args (($or_simplify_rec (or a true false)) 
+             true))
+
+
+;-------------
+; or_simplify
+;-------------
+
+; Some constants to build terms, for testing purposes.
+(declare-const a Bool)
+(declare-const b Bool)
+(declare-const c Bool)
+
+; First case of $or_simplify_rec
+(step $test_$or_simplify
+      (@cl (= false false))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false false) false))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false false false) false))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false false false false) false))
+      :rule or_simplify)
+
+; Second case of $or_simplify_rec
+(step $test_$or_simplify
+      (@cl (= (or a false) a))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false a) a))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false a false) a))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false false a false) a))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false false false a) a))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false a false b) 
+              ($f_list_cons or a b)))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false a b c false) 
+              ($f_list_cons or a ($f_list_cons or b c))))
+      :rule or_simplify)
+
+; Third case of $or_simplify_rec
+(step $test_$or_simplify
+      (@cl (= (or a a false) a))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or a false a) a))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or a false a false) a))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false a false a false) a))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false a a a) a))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false a b false a b) 
+              ($f_list_cons or a b)))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false a b c c false a) 
+              ($f_list_cons or b ($f_list_cons or c a))))
+      :rule or_simplify)
+
+; Fourth case of $or_simplify_rec
+(step $test_$or_simplify
+      (@cl (= (or a true) true))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or a true a) true))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or a false a true) true))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false a true a false) true))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false a a true) true))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false a b false true b) 
+              true))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or false a b c c true a) 
+              true))
+      :rule or_simplify)
+
+; Fifth case of $or_simplify_rec
+(step $test_$or_simplify
+      (@cl (= (or (not a) a) 
+              true))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or a (not a)) 
+              true))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or a (not (not (not a))))
+              true))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or (not (not a)) (not (not (not a))))
+              true))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or (not (not a)) false (not (not (not a))))
+              true))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or (not (not (not (not a)))) false (not (not (not a))))
+              true))
+      :rule or_simplify)
+
+(step $test_$or_simplify
+      (@cl (= (or (not (not (not (not a)))) false (not (not (not a))) b)
+              true))
+      :rule or_simplify)
+
+;-------------
 ; not_simplify
 ;-------------
 

--- a/tests/rules/tests_tautologies.eo
+++ b/tests/rules/tests_tautologies.eo
@@ -2,7 +2,7 @@
 (include "../unit_test_services.eo")
 
 
-; Unit tests for rules that introduce tautologies.
+; Unit tests for rules that introduce tautologies and their helper programs.
 
 ;-------------
 ; $or_simplify_rec
@@ -12,28 +12,64 @@
 (declare-const b Bool)
 (declare-const c Bool)
 
-; First case of $or_simplify_rec
+; First case of $or_simplify_rec:
+; ⊥∨⋯∨⊥ ⇒ ⊥
 (step $test_$or_simplify_rec_1 true 
       :rule $assert_eq 
       :args (($or_simplify_rec (or false false)) false))
 
+(step $test_$or_simplify_rec_1 true 
+      :rule $assert_eq 
+      :args (($or_simplify_rec (or false a b false))
+             ($f_list_cons or a b)))
 
-; Second case of $or_simplify_rec
+; Second case of $or_simplify_rec:
+; 𝜑1 ∨ ⋯ ∨ 𝜑𝑛 ⇒ 𝜑1 ∨ ⋯ ∨ 𝜑𝑛′ where the right-hand side has every repeated 
+; literal removed.
 (step $test_$or_simplify_rec_2 true 
       :rule $assert_eq 
-      :args (($or_simplify_rec (or false a b false)) 
+      :args (($or_simplify_rec (or a a b)) 
              ($f_list_cons or a b)))
 
 (step $test_$or_simplify_rec_3 true 
       :rule $assert_eq 
-      :args (($or_simplify_rec (or false a b false c false)) 
+      :args (($or_simplify_rec (or a a b c c)) 
              ($f_list_cons or a ($f_list_cons or b c))))
 
 
-; Fourth case of $or_simplify_rec
+; Third case of $or_simplify_rec:
+; ⊤ ∨ ⋯ ∨ 𝜑𝑛 ⇒ ⊤
 (step $test_$or_simplify_rec_4 true 
       :rule $assert_eq 
       :args (($or_simplify_rec (or a true false)) 
+             true))
+
+(step $test_$or_simplify_rec_4b true 
+      :rule $assert_eq 
+      :args (($or_simplify_rec (or a true b)) 
+             true))
+
+(step $test_$or_simplify_rec_4c true 
+      :rule $assert_eq 
+      :args (($or_simplify_rec (or a a false true b)) 
+             true))
+
+; Fourth case of $or_simplify_rec:
+; 𝜑𝑖 ∨ ⋯ ∨ 𝜑𝑗 ∨ ⋯ ∨ 𝜑𝑛 ⇒ ⊤ and 𝜑𝑖 , 𝜑𝑗 are such that one is the
+; negation of the other formula
+(step $test_$or_simplify_rec_5 true 
+      :rule $assert_eq 
+      :args (($or_simplify_rec (or a (not a)))
+             true))
+
+(step $test_$or_simplify_rec_6 true 
+      :rule $assert_eq 
+      :args (($or_simplify_rec (or a b false b (not a)))
+             true))
+
+(step $test_$or_simplify_rec_7 true 
+      :rule $assert_eq 
+      :args (($or_simplify_rec (or a b false b (not b)))
              true))
 
 
@@ -46,7 +82,8 @@
 (declare-const b Bool)
 (declare-const c Bool)
 
-; First case of $or_simplify_rec
+; First case of or_simplify:
+; ⊥∨⋯∨⊥⇒⊥
 (step $test_$or_simplify_1
       (@cl (= false false))
       :rule or_simplify)
@@ -63,7 +100,8 @@
       (@cl (= (or false false false false) false))
       :rule or_simplify)
 
-; Second case of $or_simplify_rec
+; Second case of or_simplify
+; 𝜑1 ∨⋯∨𝜑𝑛 ⇒ 𝜑1 ∨⋯∨ 𝜑𝑛′ where the right-hand side has all ⊥literals removed.
 (step $test_$or_simplify_5
       (@cl (= (or a false) a))
       :rule or_simplify)
@@ -94,7 +132,9 @@
               ($f_list_cons or a ($f_list_cons or b c))))
       :rule or_simplify)
 
-; Third case of $or_simplify_rec
+; Third case of or_simplify
+; 𝜑1 ∨⋯∨𝜑𝑛⇒𝜑1 ∨⋯∨𝜑𝑛′ where the right-hand side has all repeated literals
+; removed
 (step $test_$or_simplify_12
       (@cl (= (or a a false) a))
       :rule or_simplify)
@@ -125,7 +165,8 @@
               ($f_list_cons or b ($f_list_cons or c a))))
       :rule or_simplify)
 
-; Fourth case of $or_simplify_rec
+; Fourth case of or_simplify
+; 𝜑1 ∨⋯∨⊤∨⋯∨𝜑𝑛 ⇒⊤
 (step $test_$or_simplify_19
       (@cl (= (or a true) true))
       :rule or_simplify)
@@ -156,7 +197,9 @@
               true))
       :rule or_simplify)
 
-; Fifth case of $or_simplify_rec
+; Fifth case of or_simplify:
+; - 𝜑𝑖 ∨ ⋯ ∨ 𝜑𝑗 ∨ ⋯ ∨ 𝜑𝑛 ⇒ ⊤ and 𝜑𝑖 , 𝜑𝑗 are such that one is the
+;   negation of the other formula
 (step $test_$or_simplify_26
       (@cl (= (or (not a) a) 
               true))


### PR DESCRIPTION
This PR is focused on the rules `not_simplify` and `or_simplify`:
- Mechanizes both rules.
- Includes a test suite for both rules.
- Misc.:
    - Minor fix in names of previous tests for eq_symmetric.
    - Continues with the slow refactoring of code, putting rules that introduce tautologies in one place, separated from the rest (moves rule `eq_symmetric` out of `alethe.eo`; adds the new rules in that new module) 