### PR TITLE
Rules/bool simplify

### DIFF
--- a/signature/programs/programs.eo
+++ b/signature/programs/programs.eo
@@ -361,7 +361,6 @@
           )
 )
 
-
 ;-------------
 ; Clauses
 ;-------------
@@ -723,6 +722,64 @@
           )
          )
 
+; program: $is_implication
+; args:
+; - formula Bool: An arbitrary boolean formula.
+; return: A boolean indicating if `formula` is built with =>
+(program $is_implication ((antecedent Bool) (consequent Bool) (formula Bool))
+
+         :signature (Bool) Bool
+
+         (
+          (
+           ($is_implication (=> antecedent consequent))
+
+           true
+           )
+
+          (
+           ($is_implication formula)
+
+           false
+           )
+          )
+         )
+
+; program: $implication_get_antecedent
+; args:
+; - formula Bool: A formula built with =>.
+; return: The antecedent of `formula`.
+; note: PRE : { `formula` be built with => }
+(program $implication_get_antecedent ((antecedent Bool) (consequent Bool))
+
+         :signature (Bool) Bool
+
+         (
+          (
+           ($implication_get_antecedent (=> antecedent consequent))
+
+           antecedent
+           )
+          )
+         )
+
+; program: $implication_get_consequent
+; args:
+; - formula Bool: A formula built with =>.
+; return: The consequent of `formula`.
+; note: PRE : { `formula` be built with => }
+(program $implication_get_consequent ((antecedent Bool) (consequent Bool))
+
+         :signature (Bool) Bool
+
+         (
+          (
+           ($implication_get_consequent (=> antecedent consequent))
+
+           consequent
+           )
+          )
+         )
 
 ;-------------
 ; contexts

--- a/signature/rules/alethe.eo
+++ b/signature/rules/alethe.eo
@@ -2976,20 +2976,6 @@
 )
 
 ;TODO
-(program $check_bool_simplify ((conclusion Bool))
-  :signature (Bool) Bool
-  (
-   (($check_bool_simplify conclusion) true)
-  )
-)
-
-;TRUST
-(declare-rule bool_simplify ((conclusion Bool))
-  :requires ((($check_bool_simplify conclusion) true))
-  :conclusion-explicit conclusion
-)
-
-;TODO
 (program $check_ac_simp ((l Bool) (r Bool))
   :signature (Bool Bool) Bool
   (

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -305,6 +305,218 @@
 )
 
 ;-----------------------
+; Rule 74: bool_simplify
+;-----------------------
+
+; program: $bool_simplify_small_step
+; args:
+; - formula Bool: A formula.
+; return: >
+;   The result from applying one of the following equivalence-preserving 
+;   transformations:
+;   - ¬(𝜑1 →𝜑2) ⇒(𝜑1 ∧¬𝜑2)
+;   - ¬(𝜑1 ∨𝜑2) ⇒(¬𝜑1 ∧¬𝜑2)
+;   - ¬(𝜑1 ∧𝜑2) ⇒(¬𝜑1 ∨¬𝜑2)
+;   - (𝜑1 →(𝜑2 →𝜑3)) ⇒(𝜑1 ∧𝜑2) → 𝜑3
+;   - ((𝜑1 →𝜑2) →𝜑2) ⇒(𝜑1 ∨𝜑2)
+;   - (𝜑1 ∧(𝜑1 →𝜑2)) ⇒(𝜑1 ∧𝜑2)
+;   - ((𝜑1 →𝜑2) ∧𝜑1) ⇒(𝜑1 ∧𝜑2)
+(program $bool_simplify_small_step ((phi1 Bool) (phi2 Bool :list) (phi3 Bool :list))
+  :signature (Bool) Bool
+  (
+   (
+    ($bool_simplify_small_step (not (=> phi1 phi2)))
+
+    ($f_list_cons and phi1 (not phi2))
+    )
+
+   (
+    ($bool_simplify_small_step (not (or phi1 phi2)))
+
+    ($f_list_cons and (not phi1) (not phi2))
+    )
+
+   (
+    ($bool_simplify_small_step (not (and phi1 phi2)))
+
+    ($f_list_cons or (not phi1) (not phi2))
+    )
+
+   (
+    ($bool_simplify_small_step (=> phi1 (=> phi2 phi3)))
+    
+    (=> ($f_list_cons and phi1 phi2) phi3)
+    )
+
+   (
+    ($bool_simplify_small_step (=> (=> phi1 phi2) phi2))
+
+    ($f_list_cons or phi1 phi2)
+    )
+
+   (
+    ($bool_simplify_small_step (and (=> phi3 phi2) phi3))
+
+    ($f_list_cons and phi3 phi2)
+    )
+
+   (; { phi1 != (=> phi3 phi2) }
+    ($bool_simplify_small_step (and phi1 phi2))
+
+    ; Check which case we are into.
+    (eo::ite ($is_implication phi2)
+
+             (eo::define
+              
+              (
+               (antecedent ($implication_get_antecedent phi2))
+
+               (consequent ($implication_get_consequent phi2))
+               )
+
+              (eo::ite ($eo_is_eq phi1 antecedent)
+
+                       ; Sixth case of bool_simplify.
+                       ($f_list_cons and phi1 consequent)
+
+                       ; { not ($eo_is_eq phi1 antecedent) }
+                       ($f_list_cons and phi1 phi2)))
+
+             ; { not ($is_implication phi2) }
+             ($f_list_cons and phi1 phi2))
+    )
+
+   (
+    ($bool_simplify_small_step phi1)
+
+    phi1
+    )
+  )
+)
+
+; program: $bool_simplify_rec
+; args:
+; - formula Bool: A formula.
+; return: >
+;   The result from applying the equivalence-preserving transformations described
+;   in `$bool_simplify_small_step` until a fixed point is reached.
+(program $bool_simplify_rec ((operator (-> Bool Bool Bool)) (op Bool)
+                             (ops Bool :list))
+  :signature (Bool) Bool
+  (
+   (
+    ($bool_simplify_rec (not op))
+
+    (eo::define 
+
+     ; We reduce top-to-bottom
+     ((whole_exp_simplified ($bool_simplify_small_step (not op))))
+
+     (eo::ite ($eo_is_eq whole_exp_simplified (not op))
+
+              ; We continue reducing the sub-term
+              (eo::define 
+
+               ((op_simplified ($bool_simplify_rec op)))
+
+               (eo::ite ($eo_is_eq op_simplified op)
+
+                        ; We reached to a fixed point.
+                        (not op)
+
+                                   
+                         ; { not ($eo_is_eq op_simplified op) }
+                         ($bool_simplify_rec (not op_simplified))))
+
+              ; { not ($eo_is_eq whole_exp_simplified (not op)) }
+              ($bool_simplify_rec whole_exp_simplified)))
+    )
+
+   (
+    ($bool_simplify_rec (operator op ops))
+
+    (eo::define 
+
+     ; We reduce top-to-bottom
+     ((whole_exp_simplified ($bool_simplify_small_step (operator op ops))))
+
+     (eo::ite ($eo_is_eq whole_exp_simplified (operator op ops))
+
+              ; We continue reducing, right-to-left.
+              (eo::define 
+
+               ((ops_simplified ($bool_simplify_rec ops)))
+
+               (eo::ite ($eo_is_eq ops_simplified ops)
+
+                        (eo::define 
+
+                         ((op_simplified ($bool_simplify_rec op)))
+
+                         (eo::ite ($eo_is_eq op_simplified
+                                             op)
+
+                                   ; We reached to a fixed point.
+                                   (operator op ops)
+
+                                   
+                                   ; { not ($eo_is_eq op_simplified op) }
+                                   ($bool_simplify_rec (operator op_simplified 
+                                                                 ops))))
+
+                        ; { not ($eo_is_eq ops_simplified ops) }
+                        ($bool_simplify_rec (operator op ops_simplified))))
+
+              ; { not ($eo_is_eq whole_op_simplified 
+              ;                  (operator op ops)) }
+              ($bool_simplify_rec whole_exp_simplified)))
+    )
+   
+
+   ( ; { op != operator ...}
+     ($bool_simplify_rec op)
+
+     op
+     )
+    )
+  )
+
+; program: $check_bool_simplify
+; args:
+; - lhs Bool: >
+;   The left-hand side of the equality in the conclusion passed to rule 
+;   `bool_simplify`
+; - rhs: >
+;   The right-hand side of the equality in the conclusion passed to rule 
+;   `bool_simplify`
+; return: >
+;   A boolean indicating if `lhs` can be reduced to `rhs` using 
+;   `$bool_simplify_rec`.
+(program $check_bool_simplify ((lhs Bool) (rhs Bool))
+  :signature (Bool Bool) Bool
+  (
+   (
+    ($check_bool_simplify lhs rhs)
+
+    ($eo_is_eq ($bool_simplify_rec lhs)
+
+               rhs)
+    )
+  )
+)
+
+; rule: bool_simplify
+; requires: >
+;   For `lhs` to be reducible to `rhs` following the rules 
+;   in `$bool_simplify_rec`.
+; conclusion-explicit: (@cl (= lhs rhs))
+(declare-rule bool_simplify ((lhs Bool) (rhs Bool))
+  :requires ((($check_bool_simplify lhs rhs) true))
+  :conclusion-explicit (@cl (= lhs rhs))
+)
+
+
+;-----------------------
 ; Rule 86: prod_simplify
 ;-----------------------
 

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -176,7 +176,7 @@
                (eo::ite ($eo_is_eq whole_disjunct_simplified 
                                    (or disjunct disjuncts))
 
-                        ; We reached to a fixed point.
+                        ; We reached a fixed point.
                         (or disjunct disjuncts)
 
                         ; { not ($eo_is_eq whole_disjunct_simplified 
@@ -421,7 +421,7 @@
 
                (eo::ite ($eo_is_eq op_simplified op)
 
-                        ; We reached to a fixed point.
+                        ; We reached a fixed point.
                         (not op)
 
                                    
@@ -456,7 +456,7 @@
                          (eo::ite ($eo_is_eq op_simplified
                                              op)
 
-                                   ; We reached to a fixed point.
+                                   ; We reached a fixed point.
                                    (operator op ops)
 
                                    
@@ -483,12 +483,8 @@
 
 ; program: $check_bool_simplify
 ; args:
-; - lhs Bool: >
-;   The left-hand side of the equality in the conclusion passed to rule 
-;   `bool_simplify`
-; - rhs: >
-;   The right-hand side of the equality in the conclusion passed to rule 
-;   `bool_simplify`
+; - lhs Bool: The left-hand side of the equality in the conclusion passed to rule  `bool_simplify`
+; - rhs Bool: The right-hand side of the equality in the conclusion passed to rule `bool_simplify`
 ; return: >
 ;   A boolean indicating if `lhs` can be reduced to `rhs` using 
 ;   `$bool_simplify_rec`.

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -12,7 +12,7 @@
 ; args:
 ; - formula Bool: An arbitrary formula.
 ; return: >
-;   The result from removing leading double negations from `formula`.
+;   The result of removing leading double negations from `formula`.
 (program $remove_leading_negations ((formula Bool))
          :signature (Bool) Bool
          (
@@ -34,7 +34,7 @@
 ; args:
 ; - disjunct Bool: An disjunct built with `or`.
 ; return: >
-;   The result from removing leading double negations from each disjunct
+;   The result of removing leading double negations from each disjunct
 ;   in `disjunct`.
 (program $remove_leading_negations_in_disjuncts ((disjunct Bool) (disjuncts Bool :list))
          :signature (Bool) Bool
@@ -59,7 +59,7 @@
 ; args:
 ; - formula Bool: A formula.
 ; return: >
-;   The result from applying one of the following equivalence-preserving 
+;   The result of applying one of the following equivalence-preserving 
 ;   transformations:
 ;   - ⊥∨⋯∨⊥ ⇒ ⊥
 ;   - 𝜑1 ∨ ⋯ ∨ 𝜑𝑛 ⇒ 𝜑1 ∨ ⋯ ∨ 𝜑𝑛′ where the right-hand side has some ⊥ literal 
@@ -151,7 +151,7 @@
 ; args:
 ; - formula Bool: A formula.
 ; return: >
-;   The result from applying the equivalence-preserving transformations described
+;   The result of applying the equivalence-preserving transformations described
 ;   in `$or_simplify_small_step` until a fixed point is reached.
 ; note: PRE : { $remove_leading_negations_in_disjuncts `formula` = `formula`}
 (program $or_simplify_rec ((disjunct Bool) (disjuncts Bool :list))
@@ -238,7 +238,7 @@
 ; args:
 ; - psi Bool: A formula.
 ; return: >
-;   The result from applying the following equivalence-preserving transformations until
+;   The result of applying the following equivalence-preserving transformations until
 ;   a fixed point is reached:
 ;   - ¬(¬ ᴪ) ⇒ ᴪ
 ;   - ¬⊥ ⇒ ⊤
@@ -312,15 +312,15 @@
 ; args:
 ; - formula Bool: A formula.
 ; return: >
-;   The result from applying one of the following equivalence-preserving 
+;   The result of applying one of the following equivalence-preserving 
 ;   transformations:
-;   - ¬(𝜑1 →𝜑2) ⇒(𝜑1 ∧¬𝜑2)
-;   - ¬(𝜑1 ∨𝜑2) ⇒(¬𝜑1 ∧¬𝜑2)
-;   - ¬(𝜑1 ∧𝜑2) ⇒(¬𝜑1 ∨¬𝜑2)
-;   - (𝜑1 →(𝜑2 →𝜑3)) ⇒(𝜑1 ∧𝜑2) → 𝜑3
-;   - ((𝜑1 →𝜑2) →𝜑2) ⇒(𝜑1 ∨𝜑2)
-;   - (𝜑1 ∧(𝜑1 →𝜑2)) ⇒(𝜑1 ∧𝜑2)
-;   - ((𝜑1 →𝜑2) ∧𝜑1) ⇒(𝜑1 ∧𝜑2)
+;   - ¬(𝜑1 → 𝜑2) ⇒ (𝜑1 ∧ ¬𝜑2)
+;   - ¬(𝜑1 ∨ 𝜑2) ⇒ (¬𝜑1 ∧ ¬𝜑2)
+;   - ¬(𝜑1 ∧ 𝜑2) ⇒ (¬𝜑1 ∨ ¬𝜑2)
+;   - (𝜑1 → (𝜑2 → 𝜑3)) ⇒ (𝜑1 ∧ 𝜑2) → 𝜑3
+;   - ((𝜑1 → 𝜑2) → 𝜑2) ⇒ (𝜑1 ∨ 𝜑2)
+;   - (𝜑1 ∧ (𝜑1 → 𝜑2)) ⇒ (𝜑1 ∧ 𝜑2)
+;   - ((𝜑1 → 𝜑2) ∧ 𝜑1) ⇒ (𝜑1 ∧ 𝜑2)
 (program $bool_simplify_small_step ((phi1 Bool) (phi2 Bool :list) (phi3 Bool :list))
   :signature (Bool) Bool
   (
@@ -398,7 +398,7 @@
 ; args:
 ; - formula Bool: A formula.
 ; return: >
-;   The result from applying the equivalence-preserving transformations described
+;   The result of applying the equivalence-preserving transformations described
 ;   in `$bool_simplify_small_step` until a fixed point is reached.
 (program $bool_simplify_rec ((operator (-> Bool Bool Bool)) (op Bool)
                              (ops Bool :list))
@@ -445,9 +445,9 @@
               ; We continue reducing, right-to-left.
               (eo::define 
 
-               ((ops_simplified ($bool_simplify_rec ops)))
+               ((tail_simplified ($bool_simplify_rec ops)))
 
-               (eo::ite ($eo_is_eq ops_simplified ops)
+               (eo::ite ($eo_is_eq tail_simplified ops)
 
                         (eo::define 
 
@@ -464,8 +464,8 @@
                                    ($bool_simplify_rec (operator op_simplified 
                                                                  ops))))
 
-                        ; { not ($eo_is_eq ops_simplified ops) }
-                        ($bool_simplify_rec (operator op ops_simplified))))
+                        ; { not ($eo_is_eq tail_simplified ops) }
+                        ($bool_simplify_rec (operator op tail_simplified))))
 
               ; { not ($eo_is_eq whole_op_simplified 
               ;                  (operator op ops)) }

--- a/tests/rules/tests_tautologies.eo
+++ b/tests/rules/tests_tautologies.eo
@@ -300,6 +300,169 @@
       (@cl (= (* 1.0 2.0 3.0 4.0) 24.0)) 
       :rule prod_simplify)
 
+;-------------------------
+; $bool_simplify_small_step
+;-------------------------
+; Some constants to build terms, for testing purposes.
+(declare-const a Bool)
+(declare-const b Bool)
+(declare-const c Bool)
+
+; First case of $bool_simplify_small_step
+(step $test_$bool_simplify_small_step_1 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_small_step (not (=> a b)))
+             ($f_list_cons and a (not b))))
+
+; Second case of $bool_simplify_small_step
+(step $test_$bool_simplify_small_step_2 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_small_step (not ($f_list_cons or a b)))
+             ($f_list_cons and (not a) (not b))))
+
+; Third case of $bool_simplify_small_step
+(step $test_$bool_simplify_small_step_3 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_small_step (not ($f_list_cons and a b)))
+             ($f_list_cons or (not a) (not b))))
+
+; Fourth case of $bool_simplify_small_step
+(step $test_$bool_simplify_small_step_4 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_small_step (=> a (=> b c)))
+             (=> ($f_list_cons and a b) c)))
+
+; Fifth case of $bool_simplify_small_step
+(step $test_$bool_simplify_small_step_5 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_small_step (=> (=> a b) b))
+             ($f_list_cons or a b)))
+
+; Sixth case of $bool_simplify_small_step
+(step $test_$bool_simplify_small_step_6 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_small_step ($f_list_cons and a (=> a b)))
+             ($f_list_cons and a b)))
+
+; Seventh case of $bool_simplify_small_step
+(step $test_$bool_simplify_small_step_7 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_small_step ($f_list_cons and (=> a b) a))
+             ($f_list_cons and a b)))
+
+
+
+;-------------------
+; $bool_simplify_rec
+;-------------------
+; Some constants to build terms, for testing purposes.
+(declare-const a Bool)
+(declare-const b Bool)
+(declare-const c Bool)
+
+; First case of $bool_simplify_rec
+(step $test_$bool_simplify_rec_1 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_rec (not (=> a b)))
+             ($f_list_cons and a (not b))))
+
+; Second case of $bool_simplify_rec
+(step $test_$bool_simplify_rec_2 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_rec (not ($f_list_cons or a b)))
+             ($f_list_cons and (not a) (not b))))
+
+; Third case of $bool_simplify_rec
+(step $test_$bool_simplify_rec_3 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_rec (not ($f_list_cons and a b)))
+             ($f_list_cons or (not a) (not b))))
+
+; Fourth case of $bool_simplify_rec
+(step $test_$bool_simplify_rec_4 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_rec (=> a (=> b c)))
+             (=> ($f_list_cons and a b) c)))
+
+; Fifth case of $bool_simplify_rec
+(step $test_$bool_simplify_rec_5 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_rec (=> (=> a b) b))
+             ($f_list_cons or a b)))
+
+; Sixth case of $bool_simplify_rec
+(step $test_$bool_simplify_rec_6 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_rec ($f_list_cons and a (=> a b)))
+             ($f_list_cons and a b)))
+
+; Seventh case of $bool_simplify_rec
+(step $test_$bool_simplify_rec_7 true 
+      :rule $assert_eq 
+      :args (($bool_simplify_rec ($f_list_cons and (=> a b) a))
+             ($f_list_cons and a b)))
+
+;-------------
+; bool_simplify
+;-------------
+
+; Some constants to build terms, for testing purposes.
+(declare-const a Bool)
+(declare-const b Bool)
+(declare-const c Bool)
+(declare-const d Bool)
+(declare-const e Bool)
+(declare-const p (-> Bool Bool))
+
+; First case
+(step $test_$bool_simplify_1
+      (@cl (= (not (=> a b)) ($f_list_cons and a (not b))))
+      :rule bool_simplify)
+
+; Second case
+(step $test_$bool_simplify_2
+      (@cl (= (not ($f_list_cons or a b)) ($f_list_cons and (not a) (not b))))
+      :rule bool_simplify)
+
+; Third case
+(step $test_$bool_simplify_3
+      (@cl (= (not ($f_list_cons and a b)) ($f_list_cons or (not a) (not b))))
+      :rule bool_simplify)
+
+; Fourth case
+(step $test_$bool_simplify_4
+      (@cl (= (=> a (=> b c)) (=> ($f_list_cons and a b) c)))
+      :rule bool_simplify)
+
+; Fifth case
+(step $test_$bool_simplify_5
+      (@cl (= (=> (=> a b) b) ($f_list_cons or a b)))
+      :rule bool_simplify)
+
+; Sixth case
+(step $test_$bool_simplify_6
+      (@cl (= ($f_list_cons and a (=> a b)) ($f_list_cons and a b)))
+      :rule bool_simplify)
+
+; Seventh case
+(step $test_$bool_simplify_7
+      (@cl (= ($f_list_cons and (=> a b) a) ($f_list_cons and a b)))
+      :rule bool_simplify)
+
+; Misc.
+(step $test_$bool_simplify_misc_1
+      (@cl (= (=> (p a) 
+                 (=> ($f_list_cons or (= a b) e) 
+                    (p c))) 
+
+              (=> ($f_list_cons and (p a) 
+                      ($f_list_cons or (= a b) e)) 
+                 (p c))))
+      :rule bool_simplify)
+
+
+
+
 ;-------------
 ; eq_symmetric
 ;-------------

--- a/tests/rules/tests_tautologies.eo
+++ b/tests/rules/tests_tautologies.eo
@@ -472,6 +472,21 @@
       (@cl (= (not ($f_list_cons and a b)) ($f_list_cons or (not a) (not b))))
       :rule bool_simplify)
 
+(step $test_$bool_simplify_3b
+      (@cl (= (not ($f_list_cons and a ($f_list_cons and b c)))
+              ($f_list_cons or (not a) ($f_list_cons or (not b) (not c)))))
+      :rule bool_simplify)
+
+(step $test_$bool_simplify_3c
+      (@cl (= (not ($f_list_cons and a 
+                                 ($f_list_cons and b ($f_list_cons and c d))))
+              ($f_list_cons or 
+                            (not a) 
+                            ($f_list_cons or 
+                                          (not b) 
+                                          ($f_list_cons or (not c) (not d))))))
+      :rule bool_simplify)
+
 ; Fourth case
 (step $test_$bool_simplify_4
       (@cl (= (=> a (=> b c)) (=> ($f_list_cons and a b) c)))
@@ -483,6 +498,10 @@
       :rule bool_simplify)
 
 ; Sixth case
+(step $test_$bool_simplify_6
+      (@cl (= ($f_list_cons and a (=> a b)) ($f_list_cons and a b)))
+      :rule bool_simplify)
+
 (step $test_$bool_simplify_6
       (@cl (= ($f_list_cons and a (=> a b)) ($f_list_cons and a b)))
       :rule bool_simplify)

--- a/tests/rules/tests_tautologies.eo
+++ b/tests/rules/tests_tautologies.eo
@@ -350,6 +350,7 @@
 (declare-const a Bool)
 (declare-const b Bool)
 (declare-const c Bool)
+(declare-const d Bool)
 
 ; First case of $bool_simplify_small_step
 (step $test_$bool_simplify_small_step_1 true 
@@ -363,11 +364,31 @@
       :args (($bool_simplify_small_step (not ($f_list_cons or a b)))
              ($f_list_cons and (not a) (not b))))
 
+(step $test_$bool_simplify_small_step_2b true 
+      :rule $assert_eq 
+      :args (($bool_simplify_small_step (not ($f_list_cons or a ($f_list_cons or b c))))
+             ($f_list_cons and (not a) (not ($f_list_cons or b c)))))
+
+(step $test_$bool_simplify_small_step_2c true 
+      :rule $assert_eq 
+      :args (($bool_simplify_small_step (not ($f_list_cons or a ($f_list_cons or b ($f_list_cons or c d)))))
+             ($f_list_cons and (not a) (not ($f_list_cons or b ($f_list_cons or c d))))))
+
 ; Third case of $bool_simplify_small_step
 (step $test_$bool_simplify_small_step_3 true 
       :rule $assert_eq 
       :args (($bool_simplify_small_step (not ($f_list_cons and a b)))
              ($f_list_cons or (not a) (not b))))
+
+(step $test_$bool_simplify_small_step_3b true 
+      :rule $assert_eq 
+      :args (($bool_simplify_small_step (not ($f_list_cons and a ($f_list_cons and b c))))
+             ($f_list_cons or (not a) (not ($f_list_cons and b c)))))
+
+(step $test_$bool_simplify_small_step_3c true 
+      :rule $assert_eq 
+      :args (($bool_simplify_small_step (not ($f_list_cons and ($f_list_cons and a b) ($f_list_cons and c d))))
+             ($f_list_cons or (not ($f_list_cons and a b)) (not ($f_list_cons and c d)))))
 
 ; Fourth case of $bool_simplify_small_step
 (step $test_$bool_simplify_small_step_4 true 
@@ -402,6 +423,7 @@
 (declare-const a Bool)
 (declare-const b Bool)
 (declare-const c Bool)
+(declare-const d Bool)
 
 ; First case of $bool_simplify_rec
 (step $test_$bool_simplify_rec_1 true 
@@ -415,11 +437,31 @@
       :args (($bool_simplify_rec (not ($f_list_cons or a b)))
              ($f_list_cons and (not a) (not b))))
 
+(step $test_$bool_simplify_rec_2b true 
+      :rule $assert_eq 
+      :args (($bool_simplify_rec (not ($f_list_cons or a ($f_list_cons or b c))))
+             ($f_list_cons and (not a) ($f_list_cons and (not b) (not c)))))
+
+(step $test_$bool_simplify_rec_2c true 
+      :rule $assert_eq 
+      :args (($bool_simplify_rec (not ($f_list_cons or a ($f_list_cons or b ($f_list_cons or c d)))))
+             ($f_list_cons and (not a) ($f_list_cons and (not b) ($f_list_cons and (not c) (not d))))))
+
 ; Third case of $bool_simplify_rec
 (step $test_$bool_simplify_rec_3 true 
       :rule $assert_eq 
       :args (($bool_simplify_rec (not ($f_list_cons and a b)))
              ($f_list_cons or (not a) (not b))))
+
+(step $test_$bool_simplify_rec_3b true 
+      :rule $assert_eq 
+      :args (($bool_simplify_rec (not ($f_list_cons and a ($f_list_cons and b c))))
+             ($f_list_cons or (not a) ($f_list_cons or (not b) (not c)))))
+
+(step $test_$bool_simplify_rec_3c true 
+      :rule $assert_eq 
+      :args (($bool_simplify_rec (not ($f_list_cons and a ($f_list_cons and b ($f_list_cons and c d)))))
+             ($f_list_cons or (not a) ($f_list_cons or (not b) ($f_list_cons or (not c) (not d))))))
 
 ; Fourth case of $bool_simplify_rec
 (step $test_$bool_simplify_rec_4 true 


### PR DESCRIPTION
This PR focuses on rule bool_simplify:
- rule definitions + its checker
- corresponding test suites
- note that it also includes a query service to check if some term is an implication, and to get its components. While it looks weird, it is done like that since I cannot match against a term in the "middle" of a program, when I need to check if some formula is indeed an implication. 