### PR TITLE
eq_congruent + eq_congruent_pred

### DIFF
--- a/signature/rules/alethe.eo
+++ b/signature/rules/alethe.eo
@@ -2068,34 +2068,6 @@
   :conclusion-explicit conclusion
 )
 
-;TODO
-(program $check_eq_congruent ((conclusion Bool))
-  :signature (Bool) Bool
-  (
-   (($check_eq_congruent conclusion) true)
-  )
-)
-
-;TRUST
-(declare-rule eq_congruent ((conclusion Bool))
-  :requires ((($check_eq_congruent conclusion) true))
-  :conclusion-explicit conclusion
-)
-
-;TODO
-(program $check_eq_congruent_pred ((conclusion Bool))
-  :signature (Bool) Bool
-  (
-   (($check_eq_congruent_pred conclusion) true)
-  )
-)
-
-;TRUST
-(declare-rule eq_congruent_pred ((conclusion Bool))
-  :requires ((($check_eq_congruent_pred conclusion) true))
-  :conclusion-explicit conclusion
-)
-
 ;TODO: to preserve previous def
 ; 
 ; (program $check_qnt_cnf ((phi Bool) (phiP Bool) (xs @VarList) (xsP @VarList))

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -112,20 +112,34 @@
 ; Rule 28: eq_congruent_pred
 ;---------------------------
 
-;TODO
-(program $check_eq_congruent_pred ((conclusion Bool))
+; program: $check_eq_congruent_pred
+; args:
+; - conclusion Bool: Conclusion clause given to rule cong.
+; return: >
+;   A boolean indicating if `conclusion` has the form 
+;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), (P 𝑡1 ⋯ 𝑡𝑛) ≈ (P 𝑢1 ⋯ 𝑢𝑛), for some n-ary 
+;   function symbol P, with co-domain sort Bool.
+(program $check_eq_congruent_pred ((hd Bool) (tail Bool :list))
   :signature (Bool) Bool
   (
-   (($check_eq_congruent_pred conclusion) true)
-  )
-)
+   (
+    ($check_eq_congruent_pred (@cl hd tail))
 
-;TRUST
+    ($check_eq_congruent (@cl hd tail))
+     )
+    )
+   )
+
+; rule: eq_congruent_pred
+; requires: >
+;   For the conclusion to be built with @cl and to have the form:
+;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), (P 𝑡1 ⋯ 𝑡𝑛) ≈ (P 𝑢1 ⋯ 𝑢𝑛), 
+;   where 𝑃 is a function symbol with co-domain sort Bool.
+; conclusion-explicit: A clause built with @cl.
 (declare-rule eq_congruent_pred ((hd Bool) (tail Bool :list))
   :requires ((($check_eq_congruent_pred (@cl hd tail)) true))
   :conclusion-explicit (@cl hd tail)
 )
-
 
 ;-----------------------
 ; Rule 73: or_simplify

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -87,33 +87,42 @@
 
 ; program: $check_n_ary_application_eq_congruent_pred
 ; args:
-; - not_p Bool: >
-;   Second-to-last disjunct in the conclusion passed to the eq_congruent_pred rule.
-; - p Bool: Last disjunct in the conclusion passed to the eq_congruent rule.
+; - not_p_app Bool: >
+;   For a conclusion of an instantiation of the rule `eq_congruent_pred`, of the
+;   form ¬(𝑡1 ≈ 𝑢1), … ,¬(𝑡𝑛 ≈ 𝑢𝑛), ¬(p 𝑡1 ⋯ 𝑡𝑛), (p 𝑢1 ⋯ 𝑢𝑛), this parameter should
+;   be the term ¬(p 𝑡1 ⋯ 𝑡𝑛).
+; - p_app Bool: The term (p 𝑢1 ⋯ 𝑢𝑛) in the conclusion of the instantiation of the `eq_congruent_pred` rule.
 ; - assumptions Bool: >
-;    Clause with the assumptions of the form ¬(𝑡i ≈ 𝑢i) present in the conclusion
-;    passed to the rule, but in the reverse order.
+;    Clause with the assumptions of the form ¬(𝑡i ≈ 𝑢i) present in the instantiation
+;    of the rule, but in the reverse order.
 ; return: >
-;    A boolean indicating if `not_p`, `p` and `assumptions` correspond to the proper
-;    application of the eq_congruent_pred rule, for a n-ary predicate.
+;    A boolean indicating if `not_p_app`, `p_app` and `assumptions` correspond to 
+;    a proper instantiation of the `eq_congruent_pred` rule, for a n-ary predicate.
 (program $check_n_ary_application_eq_congruent_pred ((T Type) (U Type) 
-                                                     (p (-> T U Bool)) (p2 (-> T U Bool)) 
-                                                     (t1 T) (t2 T)
+                                                     (p (-> T U Bool)) 
+                                                     (lhs_p (-> T U Bool))
+                                                     (rhs_p (-> T U Bool))
+                                                     (t1 T) (u1 T)
+                                                     (ti T) (ui T)
                                                      (tail Bool :list))
     :signature (Bool Bool Bool) Bool
     (
-     (
-      ($check_n_ary_application_eq_congruent_pred (not (p t1)) (p t2) 
-                                                  (@cl (not (= t1 t2))))
+     (; First part of the (not (p ...)) and (p ...) terms.
+      ($check_n_ary_application_eq_congruent_pred (not (p t1)) (p u1) 
+                                                  (@cl (not (= t1 u1))))
 
       true
       )
 
-     ( ; TODO: ill-typed?
-      ($check_n_ary_application_eq_congruent_pred (not (p t1)) (p2 t2)
-                                                  (@cl (not (= t1 t2)) tail))
+     (; TODO: ill-typed?
+      ; For a conclusion of the form:
+      ; ¬(𝑡1 ≈ 𝑢1), ... ,¬(𝑡𝑛 ≈ 𝑢𝑛), ¬(p 𝑡1 ... 𝑡𝑛), (p 𝑢1 ... 𝑢𝑛),
+      ; (lhs_p ti) should be the term (p 𝑡1 ... 𝑡i) while (rhs_p ui) should be 
+      ; (p 𝑢1 ... ui ), for some i <= n.
+      ($check_n_ary_application_eq_congruent_pred (not (lhs_p ti)) (rhs_p ui)
+                                                  (@cl (not (= ti ui)) tail))
 
-      ($check_n_ary_application_eq_congruent_pred (not p) p2 tail)
+      ($check_n_ary_application_eq_congruent_pred (not lhs_p) rhs_p tail)
       )
      )
     )

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -5,6 +5,129 @@
 ; Rules that introduce tautologies.
 
 ;-----------------------
+; Rule 27: eq_congruent
+;-----------------------
+
+
+
+;; ; program: $eq_congruent_get_last_equality
+;; ; args:
+;; ; - conclusion Bool: >
+;; ;   Conclusion passed to the rule eq_congruent. Must have the form
+;; ;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), (𝑓 𝑡1 ⋯ 𝑡𝑛) ≈ (𝑓 𝑢1 ⋯ 𝑢𝑛)
+;; ; return: The last disjunct, (𝑓 𝑡1 ⋯ 𝑡𝑛) ≈ (𝑓 𝑢1 ⋯ 𝑢𝑛).
+;; (program $eq_congruent_get_last_equality ()
+
+;;          :signature (Bool) Bool
+
+;;          (
+;;           (
+;;            ($eq_congruent_get_last_equality (@cl (= (f t1) (f t2))))
+
+;;            (= (f t1) (f t2))
+;;            )
+
+;;           (
+;;            ($eq_congruent_get_last_equality (@cl (not (= a b)) tail))
+
+;;            ($eq_congruent_get_last_equality tail)
+;;            )
+;;           )
+;;          )
+
+; program: $check_n_ary_application_eq_congruent
+; args:
+; - eq Bool: Last equality in the conclusion passed to the eq_congruent rule.
+; - assumptions Bool: >
+;    Clause with the assumptions of the form ¬(𝑡i ≈ 𝑢i) present in the conclusion
+;    passed to the rule, but in the reverse order.
+; return: >
+;    A boolean indicating if `eq` and `assumptions` correspond to the proper
+;    application of the eq_congruent rule, for a n-ary operator. Note that, in 
+;    this case, we are dealing with the single application of a n-ary operator. No 
+;    associativity is involved.
+(program $check_n_ary_application_eq_congruent ((T Type) (U Type) 
+                                                (f (-> T U U)) (f2 (-> T U U)) 
+                                                (t1 T) (t2 T)
+                                                (tail Bool :list))
+    :signature (Bool Bool) Bool
+    (
+     (
+      ($check_n_ary_application_eq_congruent (= (f t1) (f t2)) (@cl (not (= t1 t2))))
+
+      true
+      )
+
+     ( ; TODO: ill-typed?
+      ($check_n_ary_application_eq_congruent (= (f t1) (f2 t2)) (@cl (not (= t1 t2)) tail))
+
+      ($check_n_ary_application_eq_congruent (= f f2) tail)
+      )
+     )
+    )
+
+; program: $check_eq_congruent
+; args:
+; - conclusion Bool: Conclusion clause given to rule cong.
+; return: >
+;   A boolean indicating if `conclusion` has the form 
+;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), (𝑓 𝑡1 ⋯ 𝑡𝑛) ≈ (𝑓 𝑢1 ⋯ 𝑢𝑛), for some n-ary 
+;   function `f`.
+(program $check_eq_congruent ((hd Bool) (tail Bool :list))
+  :signature (Bool) Bool
+  (
+   (
+    ($check_eq_congruent (@cl hd tail))
+
+    (eo::define
+
+     (
+      (equality ($f_list_last_element @cl false (@cl hd tail)))
+      )
+     
+     (eo::define
+      
+      (
+       (assumptions ($f_list_remove_elem @cl (@cl hd tail) equality false))
+       )
+
+     ($check_n_ary_application_eq_congruent equality 
+                                            (eo::list_rev @cl assumptions))))
+     )
+    )
+   )
+
+
+; rule: eq_congruent
+; requires: >
+;   For the conclusion to be built with @cl and to have the form:
+;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), (𝑓 𝑡1 ⋯ 𝑡𝑛) ≈ (𝑓 𝑢1 ⋯ 𝑢𝑛)
+; conclusion-explicit: A clause built with @cl.
+(declare-rule eq_congruent ((hd Bool) (tail Bool :list))
+  :requires ((($check_eq_congruent (@cl hd tail)) true))
+  :conclusion-explicit (@cl hd tail)
+)
+
+;---------------------------
+; Rule 28: eq_congruent_pred
+;---------------------------
+
+;TODO
+(program $check_eq_congruent_pred ((conclusion Bool))
+  :signature (Bool) Bool
+  (
+   (($check_eq_congruent_pred conclusion) true)
+  )
+)
+
+;TRUST
+(declare-rule eq_congruent_pred ((hd Bool) (tail Bool :list))
+  :requires ((($check_eq_congruent_pred (@cl hd tail)) true))
+  :conclusion-explicit (@cl hd tail)
+)
+
+
+;-----------------------
 ; Rule 73: or_simplify
 ;-----------------------
 

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -44,7 +44,7 @@
 ; - conclusion Bool: Conclusion clause given to rule cong.
 ; return: >
 ;   A boolean indicating if `conclusion` has the form 
-;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), (𝑓 𝑡1 ⋯ 𝑡𝑛) ≈ (𝑓 𝑢1 ⋯ 𝑢𝑛), for some n-ary 
+;   ¬(𝑡1 ≈ 𝑢1), … ,¬(𝑡𝑛 ≈ 𝑢𝑛), (𝑓 𝑡1 ⋯ 𝑡𝑛) ≈ (𝑓 𝑢1 ⋯ 𝑢𝑛), for some n-ary 
 ;   function `f`.
 (program $check_eq_congruent ((hd Bool) (tail Bool :list))
   :signature (Bool) Bool
@@ -74,7 +74,7 @@
 ; rule: eq_congruent
 ; requires: >
 ;   For the conclusion to be built with @cl and to have the form:
-;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), (𝑓 𝑡1 ⋯ 𝑡𝑛) ≈ (𝑓 𝑢1 ⋯ 𝑢𝑛)
+;   ¬(𝑡1 ≈ 𝑢1), … ,¬(𝑡𝑛 ≈ 𝑢𝑛), (𝑓 𝑡1 ⋯ 𝑡𝑛) ≈ (𝑓 𝑢1 ⋯ 𝑢𝑛)
 ; conclusion-explicit: A clause built with @cl.
 (declare-rule eq_congruent ((hd Bool) (tail Bool :list))
   :requires ((($check_eq_congruent (@cl hd tail)) true))
@@ -123,7 +123,7 @@
 ; - conclusion Bool: Conclusion clause given to rule eq_congruent_pred.
 ; return: >
 ;   A boolean indicating if `conclusion` has the form 
-;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), ¬(p 𝑡1 ⋯ 𝑡𝑛), (p 𝑢1 ⋯ 𝑢𝑛), for some n-ary 
+;   ¬(𝑡1 ≈ 𝑢1), … ,¬(𝑡𝑛 ≈ 𝑢𝑛), ¬(p 𝑡1 ⋯ 𝑡𝑛), (p 𝑢1 ⋯ 𝑢𝑛), for some n-ary 
 ;   predicate `p`.
 (program $check_eq_congruent_pred ((hd Bool) (tail Bool :list))
   :signature (Bool) Bool
@@ -164,7 +164,7 @@
 ; rule: eq_congruent_pred
 ; requires: >
 ;   For the conclusion to be built with @cl and to have the form:
-;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), ¬(P 𝑡1 ⋯ 𝑡𝑛), (P 𝑢1 ⋯ 𝑢𝑛), 
+;   ¬(𝑡1 ≈ 𝑢1), … ,¬(𝑡𝑛 ≈ 𝑢𝑛), ¬(P 𝑡1 ⋯ 𝑡𝑛), (P 𝑢1 ⋯ 𝑢𝑛), 
 ;   where 𝑃 is a predicate symbol.
 ; conclusion-explicit: A clause built with @cl satisfying the previous side-condition.
 (declare-rule eq_congruent_pred ((hd Bool) (tail Bool :list))

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -8,33 +8,6 @@
 ; Rule 27: eq_congruent
 ;-----------------------
 
-
-
-;; ; program: $eq_congruent_get_last_equality
-;; ; args:
-;; ; - conclusion Bool: >
-;; ;   Conclusion passed to the rule eq_congruent. Must have the form
-;; ;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), (𝑓 𝑡1 ⋯ 𝑡𝑛) ≈ (𝑓 𝑢1 ⋯ 𝑢𝑛)
-;; ; return: The last disjunct, (𝑓 𝑡1 ⋯ 𝑡𝑛) ≈ (𝑓 𝑢1 ⋯ 𝑢𝑛).
-;; (program $eq_congruent_get_last_equality ()
-
-;;          :signature (Bool) Bool
-
-;;          (
-;;           (
-;;            ($eq_congruent_get_last_equality (@cl (= (f t1) (f t2))))
-
-;;            (= (f t1) (f t2))
-;;            )
-
-;;           (
-;;            ($eq_congruent_get_last_equality (@cl (not (= a b)) tail))
-
-;;            ($eq_congruent_get_last_equality tail)
-;;            )
-;;           )
-;;          )
-
 ; program: $check_n_ary_application_eq_congruent
 ; args:
 ; - eq Bool: Last equality in the conclusion passed to the eq_congruent rule.

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -85,30 +85,88 @@
 ; Rule 28: eq_congruent_pred
 ;---------------------------
 
+; program: $check_n_ary_application_eq_congruent_pred
+; args:
+; - not_p Bool: >
+;   Second-to-last disjunct in the conclusion passed to the eq_congruent_pred rule.
+; - p Bool: Last disjunct in the conclusion passed to the eq_congruent rule.
+; - assumptions Bool: >
+;    Clause with the assumptions of the form ¬(𝑡i ≈ 𝑢i) present in the conclusion
+;    passed to the rule, but in the reverse order.
+; return: >
+;    A boolean indicating if `not_p`, `p` and `assumptions` correspond to the proper
+;    application of the eq_congruent_pred rule, for a n-ary predicate.
+(program $check_n_ary_application_eq_congruent_pred ((T Type) (U Type) 
+                                                     (p (-> T U Bool)) (p2 (-> T U Bool)) 
+                                                     (t1 T) (t2 T)
+                                                     (tail Bool :list))
+    :signature (Bool Bool Bool) Bool
+    (
+     (
+      ($check_n_ary_application_eq_congruent_pred (not (p t1)) (p t2) 
+                                                  (@cl (not (= t1 t2))))
+
+      true
+      )
+
+     ( ; TODO: ill-typed?
+      ($check_n_ary_application_eq_congruent_pred (not (p t1)) (p2 t2)
+                                                  (@cl (not (= t1 t2)) tail))
+
+      ($check_n_ary_application_eq_congruent_pred (not p) p2 tail)
+      )
+     )
+    )
+
 ; program: $check_eq_congruent_pred
 ; args:
-; - conclusion Bool: Conclusion clause given to rule cong.
+; - conclusion Bool: Conclusion clause given to rule eq_congruent_pred.
 ; return: >
 ;   A boolean indicating if `conclusion` has the form 
-;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), (P 𝑡1 ⋯ 𝑡𝑛) ≈ (P 𝑢1 ⋯ 𝑢𝑛), for some n-ary 
-;   function symbol P, with co-domain sort Bool.
+;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), ¬(p 𝑡1 ⋯ 𝑡𝑛), (p 𝑢1 ⋯ 𝑢𝑛), for some n-ary 
+;   predicate `p`.
 (program $check_eq_congruent_pred ((hd Bool) (tail Bool :list))
   :signature (Bool) Bool
   (
    (
     ($check_eq_congruent_pred (@cl hd tail))
 
-    ($check_eq_congruent (@cl hd tail))
-     )
-    )
+    (eo::define
+
+     (
+      (predicate_p ($f_list_last_element @cl false (@cl hd tail)))
+      )
+     
+     (eo::define
+      
+      (
+       (remaining_elements ($f_list_remove_elem @cl (@cl hd tail) predicate_p false))
+       )
+
+      (eo::define
+
+       (
+        (predicate_not_p ($f_list_last_element @cl false remaining_elements))
+        )
+       
+       (eo::define
+        
+        (
+         (assumptions ($f_list_remove_elem @cl remaining_elements predicate_not_p false))
+         )
+
+        ($check_n_ary_application_eq_congruent_pred predicate_not_p predicate_p
+                                                    (eo::list_rev @cl assumptions))))
+      )))
    )
+  )
 
 ; rule: eq_congruent_pred
 ; requires: >
 ;   For the conclusion to be built with @cl and to have the form:
-;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), (P 𝑡1 ⋯ 𝑡𝑛) ≈ (P 𝑢1 ⋯ 𝑢𝑛), 
-;   where 𝑃 is a function symbol with co-domain sort Bool.
-; conclusion-explicit: A clause built with @cl.
+;   ¬(𝑡1 ≈ 𝑢1), … ,¬( 𝑡𝑛 ≈ 𝑢𝑛), ¬(P 𝑡1 ⋯ 𝑡𝑛), (P 𝑢1 ⋯ 𝑢𝑛), 
+;   where 𝑃 is a predicate symbol.
+; conclusion-explicit: A clause built with @cl satisfying the previous side-condition.
 (declare-rule eq_congruent_pred ((hd Bool) (tail Bool :list))
   :requires ((($check_eq_congruent_pred (@cl hd tail)) true))
   :conclusion-explicit (@cl hd tail)

--- a/tests/rules/tests_tautologies.eo
+++ b/tests/rules/tests_tautologies.eo
@@ -87,18 +87,22 @@
 (step $test_$check_eq_congruent_pred_1 true 
       :rule $assert_eq 
       :args (($check_eq_congruent_pred 
-              (@cl (not (= a b))  (= (g a) (g b)))) true))
+              (@cl (not (= a b)) (not (g a)) (g b))) 
+
+             true))
 
 (step $test_$check_eq_congruent_pred_2 true 
       :rule $assert_eq 
       :args (($check_eq_congruent_pred (@cl (not (= b d)) (not (= c e)) 
-                                            (= (f b c) (f d e)))) 
+                                            (not (f b c)) (f d e)))
+             
              true))
 
 (step $test_$check_eq_congruent_pred_3 true 
       :rule $assert_eq 
-      :args (($check_eq_congruent_pred (@cl (not (= a d)) (not (= b e)) (not (= c j)) 
-                                       (= (h a b c) (h d e j)))) 
+      :args (($check_eq_congruent_pred (@cl (not (= a d)) (not (= b e)) (not (= c j))
+                                       (not (h a b c)) (h d e j)))
+
              true))
 
 ;-------------

--- a/tests/rules/tests_tautologies.eo
+++ b/tests/rules/tests_tautologies.eo
@@ -4,6 +4,71 @@
 
 ; Unit tests for rules that introduce tautologies.
 
+;--------------------------------------
+; $check_n_ary_application_eq_congruent
+;--------------------------------------
+; Some constants to build terms, for testing purposes.
+(declare-const U Type)
+(declare-const a U)
+(declare-const b U)
+(declare-const c U)
+(declare-const d U)
+(declare-const e U)
+(declare-const j U)
+(declare-const g (-> U U))
+(declare-const f (-> U U U))
+(declare-const h (-> U U U U))
+
+(step $test_$check_n_ary_application_eq_congruent_1 true 
+      :rule $assert_eq 
+      :args (($check_n_ary_application_eq_congruent (= (g a) (g b))
+                                                    (@cl (not (= a b)))) 
+             true))
+
+(step $test_$check_n_ary_application_eq_congruent_2 true 
+      :rule $assert_eq 
+      :args (($check_n_ary_application_eq_congruent (= (f b c) (f d e))
+                                                    (@cl (not (= c e))
+                                                         (not (= b d)))) 
+             true))
+
+(step $test_$check_n_ary_application_eq_congruent_3 true 
+      :rule $assert_eq 
+      :args (($check_n_ary_application_eq_congruent (= (h a b c) (h d e j))
+              (@cl (not (= c j)) (not (= b e)) (not (= a d)))) 
+             true))
+
+;--------------------
+; $check_eq_congruent
+;--------------------
+; Some constants to build terms, for testing purposes.
+(declare-const U Type)
+(declare-const a U)
+(declare-const b U)
+(declare-const c U)
+(declare-const d U)
+(declare-const e U)
+(declare-const j U)
+(declare-const g (-> U U))
+(declare-const f (-> U U U))
+(declare-const h (-> U U U U))
+
+(step $test_$check_eq_congruent_1 true 
+      :rule $assert_eq 
+      :args (($check_eq_congruent 
+              (@cl (not (= a b))  (= (g a) (g b)))) true))
+
+(step $test_$check_eq_congruent_2 true 
+      :rule $assert_eq 
+      :args (($check_eq_congruent (@cl (not (= b d)) (not (= c e)) (= (f b c) (f d e)))) 
+             true))
+
+(step $test_$check_eq_congruent_3 true 
+      :rule $assert_eq 
+      :args (($check_eq_congruent (@cl (not (= a d)) (not (= b e)) (not (= c j)) 
+                                       (= (h a b c) (h d e j)))) 
+             true))
+
 ;-------------
 ; $or_simplify_rec
 ;-------------

--- a/tests/rules/tests_tautologies.eo
+++ b/tests/rules/tests_tautologies.eo
@@ -69,6 +69,38 @@
                                        (= (h a b c) (h d e j)))) 
              true))
 
+;--------------------
+; $check_eq_congruent_pred
+;--------------------
+; Some constants to build terms, for testing purposes.
+(declare-const U Type)
+(declare-const a U)
+(declare-const b U)
+(declare-const c U)
+(declare-const d U)
+(declare-const e U)
+(declare-const j U)
+(declare-const g (-> U U))
+(declare-const f (-> U U Bool))
+(declare-const h (-> U U U Bool))
+
+(step $test_$check_eq_congruent_pred_1 true 
+      :rule $assert_eq 
+      :args (($check_eq_congruent_pred 
+              (@cl (not (= a b))  (= (g a) (g b)))) true))
+
+(step $test_$check_eq_congruent_pred_2 true 
+      :rule $assert_eq 
+      :args (($check_eq_congruent_pred (@cl (not (= b d)) (not (= c e)) 
+                                            (= (f b c) (f d e)))) 
+             true))
+
+(step $test_$check_eq_congruent_pred_3 true 
+      :rule $assert_eq 
+      :args (($check_eq_congruent_pred (@cl (not (= a d)) (not (= b e)) (not (= c j)) 
+                                       (= (h a b c) (h d e j)))) 
+             true))
+
 ;-------------
 ; $or_simplify_rec
 ;-------------


### PR DESCRIPTION
This PR focuses on rules eq_congruent and eq_congruent_pred:
- Rule definitions.
- Small test suite (to be increased as interesting examples appear during testing against smt-lib benchmarks).