### PR TITLE
Rule qnt_rm_unused

### DIFF
--- a/signature/programs/lists.eo
+++ b/signature/programs/lists.eo
@@ -80,7 +80,7 @@
   )
 )
 
-; program: f_list_contains_elem
+; program: $f_list_contains_f_list
 ; args:
 ; - f (-> A B B): Operator used to build the f-list.
 ; - list_1 B: An f-list.
@@ -110,7 +110,7 @@
   )
 )
 
-; program: f_list_equal
+; program: $f_list_equal
 ; args:
 ; - f (-> A B B): Operator used to build the f-list.
 ; - list_1 B: An f-list.

--- a/signature/rules/alethe.eo
+++ b/signature/rules/alethe.eo
@@ -3004,20 +3004,6 @@
 )
 
 ;TODO
-(program $check_qnt_rm_unused ((conclusion Bool))
-  :signature (Bool) Bool
-  (
-   (($check_qnt_rm_unused conclusion) true)
-  )
-)
-
-;TRUST
-(declare-rule qnt_rm_unused ((conclusion Bool))
-  :requires ((($check_qnt_rm_unused conclusion) true))
-  :conclusion-explicit conclusion
-)
-
-;TODO
 (program $check_eq_simplify ((conclusion Bool))
   :signature (Bool) Bool
   (

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -928,7 +928,7 @@
 ; - conclusion Bool: Conclusion given to rule `qnt_rm_unused`.
 ; return: >
 ;   A boolean indicating if `conclusion` has the form:
-;   𝑄𝑥1, … , 𝑥𝑛. 𝜑 ≈ 𝑄 𝑥𝑘1, … , 𝑥𝑘𝑚. 𝜑
+;   𝑄 𝑥1, … , 𝑥𝑛. 𝜑 ≈ 𝑄 𝑥𝑘1, … , 𝑥𝑘𝑚. 𝜑
 ;   Where the list of variables 𝑥𝑘1, … , 𝑥𝑘𝑚 is obtained from the original list
 ;   𝑥1, … , 𝑥n, by removing variables that are already bound in 𝜑.
 (program $check_qnt_rm_unused ((varlist_1 @VarList) (varlist_2 @VarList) (phi Bool))
@@ -959,10 +959,10 @@
 ; rule: qnt_rm_unused
 ; requires: >
 ;   For the conclusion to be of the form:
-;   𝑄𝑥1, … , 𝑥𝑛. 𝜑 ≈ 𝑄 𝑥𝑘1, … , 𝑥𝑘𝑚. 𝜑
+;   𝑄 𝑥1, … , 𝑥𝑛. 𝜑 ≈ 𝑄 𝑥𝑘1, … , 𝑥𝑘𝑚. 𝜑
 ;   Where the list of variables 𝑥𝑘1, … , 𝑥𝑘𝑚 is obtained from the original list
 ;   𝑥1, … , 𝑥n, by removing variables that are already bound in 𝜑.
-; conclusion-explicit: A conclusion of the form (@cl (= lhs rhs)).
+; conclusion-explicit: A conclusion of the form (@cl (= lhs rhs)), satisfying the previous side-condition.
 (declare-rule qnt_rm_unused ((lhs Bool) (rhs Bool))
   :requires ((($check_qnt_rm_unused (@cl (= lhs rhs))) true))
   :conclusion-explicit (@cl (= lhs rhs))

--- a/signature/rules/tautologies.eo
+++ b/signature/rules/tautologies.eo
@@ -808,6 +808,95 @@
   :conclusion-explicit (@cl (= lhs rhs))
 )
 
+;-----------------------
+; Rule 83: qnt_rm_unused
+;-----------------------
+
+; program: $check_free_variables
+; args:
+; - varlist1 VarList: Original list of quantified variables.
+; - varlist2 VarList: >
+;   List of quantified variables where unused variables where removed
+; - free_variables VarList: >
+;   List of free variables in the body of the original quantified formula.
+; return: >
+;   A boolean indicating if every variable in `varlist1` that is not 
+;   present in `varlist2` does not in `free_variables` (i.e., does not 
+;   appear free in the body of the original quantified formula).
+(program $check_free_variables ((varlist1 @VarList) (varlist2 @VarList)
+                                (free_variables @VarList)
+                                (A Type) (var A) (tail A :list))
+
+         :signature (@VarList @VarList @VarList) Bool
+
+         (
+          (
+           ($check_free_variables @varlist.nil varlist2 free_variables)
+           
+           true
+           )
+
+          (
+           ($check_free_variables (@varlist var tail) varlist2 free_variables)
+           
+           (eo::ite (eo::not ($f_list_contains_elem @varlist var varlist2))
+
+                    (eo::and (eo::not ($f_list_contains_elem @varlist var free_variables))
+
+                             ($check_free_variables tail varlist2 free_variables))
+
+                    ; { (f_list_contains_elem @varlist var varlist2) }
+                    ($check_free_variables tail varlist2 free_variables))
+           )
+          )
+         )
+
+
+; program: $check_qnt_rm_unused
+; args:
+; - conclusion Bool: Conclusion given to rule `qnt_rm_unused`.
+; return: >
+;   A boolean indicating if `conclusion` has the form:
+;   𝑄𝑥1, … , 𝑥𝑛. 𝜑 ≈ 𝑄 𝑥𝑘1, … , 𝑥𝑘𝑚. 𝜑
+;   Where the list of variables 𝑥𝑘1, … , 𝑥𝑘𝑚 is obtained from the original list
+;   𝑥1, … , 𝑥n, by removing variables that are already bound in 𝜑.
+(program $check_qnt_rm_unused ((varlist_1 @VarList) (varlist_2 @VarList) (phi Bool))
+  :signature (Bool) Bool
+  (
+   (
+    ($check_qnt_rm_unused (@cl (= (forall varlist_1 phi) (forall varlist_2 phi))))
+
+    
+    (eo::and ; varlist_2 is contained in varlist_1
+             ($f_list_contains_f_list @varlist varlist_2 varlist_1)
+             
+             ($check_free_variables varlist_1 varlist_2 ($fv phi)))
+    )
+
+   (
+    ($check_qnt_rm_unused (@cl (= (exists varlist_1 phi) (exists varlist_2 phi))))
+
+    
+    (eo::and ; varlist_2 is contained in varlist_1
+             ($f_list_contains_f_list @varlist varlist_2 varlist_1)
+             
+             ($check_free_variables varlist_1 varlist_2 ($fv phi)))
+    )
+  )
+)
+
+; rule: qnt_rm_unused
+; requires: >
+;   For the conclusion to be of the form:
+;   𝑄𝑥1, … , 𝑥𝑛. 𝜑 ≈ 𝑄 𝑥𝑘1, … , 𝑥𝑘𝑚. 𝜑
+;   Where the list of variables 𝑥𝑘1, … , 𝑥𝑘𝑚 is obtained from the original list
+;   𝑥1, … , 𝑥n, by removing variables that are already bound in 𝜑.
+; conclusion-explicit: A conclusion of the form (@cl (= lhs rhs)).
+(declare-rule qnt_rm_unused ((lhs Bool) (rhs Bool))
+  :requires ((($check_qnt_rm_unused (@cl (= lhs rhs))) true))
+  :conclusion-explicit (@cl (= lhs rhs))
+)
+
 
 ;-----------------------
 ; Rule 86: prod_simplify

--- a/tests/rules/tests_tautologies.eo
+++ b/tests/rules/tests_tautologies.eo
@@ -803,7 +803,128 @@
       :rule bool_simplify)
 
 
+;----------------------
+; $check_free_variables
+;----------------------
 
+(step $test_$check_free_variables_1 true 
+      :rule $assert_eq 
+      :args (($check_free_variables (@varlist (eo::var "x" Int) (eo::var "y" Int))
+                                    (@varlist (eo::var "y" Int))
+                                    @varlist.nil)
+
+             true))
+
+(step $test_$check_free_variables_2 true 
+      :rule $assert_eq 
+      :args (($check_free_variables (@varlist (eo::var "x" Int) (eo::var "y" Int))
+                                    (@varlist (eo::var "y" Int))
+                                    (@varlist (eo::var "x" Int)))
+
+             false))
+
+(step $test_$check_free_variables_2 true 
+      :rule $assert_eq 
+      :args (($check_free_variables (@varlist (eo::var "x" Int) 
+                                              (eo::var "y" Int)
+                                              (eo::var "z" Int))
+                                    (@varlist (eo::var "y" Int)
+                                              (eo::var "z" Int))
+                                    (@varlist (eo::var "y" Int)))
+
+             true))
+
+(step $test_$check_free_variables_2 true 
+      :rule $assert_eq 
+      :args (($check_free_variables (@varlist (eo::var "x" Int) 
+                                              (eo::var "y" Int)
+                                              (eo::var "z" Int))
+                                    (@varlist (eo::var "y" Int)
+                                              (eo::var "z" Int))
+                                    (@varlist (eo::var "y" Int)
+                                              (eo::var "z" Int)))
+
+             true))
+
+;----------------------
+; $check_qnt_rm_unused
+;----------------------
+
+(step $test_$check_qnt_rm_unused_1 true 
+      :rule $assert_eq 
+      :args (($check_qnt_rm_unused 
+              (@cl (= (forall (@varlist (eo::var "x" Int) (eo::var "y" Int))
+                              (forall (@varlist (eo::var "x" Int)) true))
+                      (forall (@varlist (eo::var "y" Int))
+                              (forall (@varlist (eo::var "x" Int)) true)))))
+
+             true))
+
+(step $test_$check_qnt_rm_unused_2 true 
+      :rule $assert_eq 
+      :args (($check_qnt_rm_unused 
+              (@cl (= (forall (@varlist (eo::var "x" Int) (eo::var "y" Int)
+                                        (eo::var "z" Int))
+                              (forall (@varlist (eo::var "x" Int)) true))
+                      (forall (@varlist (eo::var "y" Int))
+                              (forall (@varlist (eo::var "x" Int)) true)))))
+
+             true))
+
+(step $test_$check_qnt_rm_unused_3 true 
+      :rule $assert_eq 
+      :args (($check_qnt_rm_unused 
+              (@cl (= (exists (@varlist (eo::var "x" Int) (eo::var "y" Int))
+                              (exists (@varlist (eo::var "x" Int)) true))
+                      (exists (@varlist (eo::var "y" Int))
+                              (exists (@varlist (eo::var "x" Int)) true)))))
+
+             true))
+
+(step $test_$check_qnt_rm_unused_4 true 
+      :rule $assert_eq 
+      :args (($check_qnt_rm_unused 
+              (@cl (= (exists (@varlist (eo::var "x" Int) (eo::var "y" Int)
+                                        (eo::var "z" Int))
+                              (exists (@varlist (eo::var "x" Int)) true))
+                      (exists (@varlist (eo::var "y" Int))
+                              (exists (@varlist (eo::var "x" Int)) true)))))
+
+             true))
+
+;----------------------
+; qnt_rm_unused
+;----------------------
+
+(step $test_qnt_rm_unused_1 
+      (@cl (= (forall (@varlist (eo::var "x" Int) (eo::var "y" Int))
+                              (forall (@varlist (eo::var "x" Int)) true))
+                      (forall (@varlist (eo::var "y" Int))
+                              (forall (@varlist (eo::var "x" Int)) true)))) 
+      :rule qnt_rm_unused)
+
+(step $test_qnt_rm_unused_2 
+      (@cl (= (forall (@varlist (eo::var "x" Int) (eo::var "y" Int)
+                                        (eo::var "z" Int))
+                              (forall (@varlist (eo::var "x" Int)) true))
+                      (forall (@varlist (eo::var "y" Int))
+                              (forall (@varlist (eo::var "x" Int)) true)))) 
+      :rule qnt_rm_unused)
+
+(step $test_qnt_rm_unused_3 
+      (@cl (= (exists (@varlist (eo::var "x" Int) (eo::var "y" Int))
+                              (exists (@varlist (eo::var "x" Int)) true))
+                      (exists (@varlist (eo::var "y" Int))
+                              (exists (@varlist (eo::var "x" Int)) true)))) 
+      :rule qnt_rm_unused)
+
+(step $test_qnt_rm_unused_4 
+      (@cl (= (exists (@varlist (eo::var "x" Int) (eo::var "y" Int)
+                                        (eo::var "z" Int))
+                              (exists (@varlist (eo::var "x" Int)) true))
+                      (exists (@varlist (eo::var "y" Int))
+                              (exists (@varlist (eo::var "x" Int)) true))))
+      :rule qnt_rm_unused)
 
 ;-------------
 ; eq_symmetric


### PR DESCRIPTION
This PR focuses on the mechanization of the rule `qnt_rm_unused`:
- Rule spec + checker + auxiliary services.
- Test suite.
- Misc.: some minor fixes in doc and function name of f-lists services.